### PR TITLE
Enhancement show all implicit objects

### DIFF
--- a/src/ChangeSetItem.php
+++ b/src/ChangeSetItem.php
@@ -192,6 +192,7 @@ class ChangeSetItem extends DataObject implements Thumbnail
      */
     public function findReferenced()
     {
+        // remove this for recursive unpublish action in a ChangeSet
         if ($this->getChangeType() === ChangeSetItem::CHANGE_DELETED) {
             // If deleted from stage, need to look at live record
             $record = $this->getObjectInStage(Versioned::LIVE);
@@ -202,12 +203,10 @@ class ChangeSetItem extends DataObject implements Thumbnail
             // If changed on stage, look at owned objects there
             $record = $this->getObjectInStage(Versioned::DRAFT);
             if ($record) {
-                return $record->findOwned()->filterByCallback(function ($owned) {
-                    /** @var Versioned|DataObject $owned */
-                    return $owned->stagesDiffer(Versioned::DRAFT, Versioned::LIVE);
-                });
+                return $record->findOwned();
             }
         }
+        
         // Empty set
         return new ArrayList();
     }

--- a/tests/php/ChangeSetTest.php
+++ b/tests/php/ChangeSetTest.php
@@ -128,7 +128,11 @@ class ChangeSetTest extends SapphireTest
         $this->assertChangeSetLooksLike(
             $cs,
             [
-            ChangeSetTest\BaseObject::class.'.base' => ChangeSetItem::EXPLICITLY
+                ChangeSetTest\BaseObject::class . '.base' => ChangeSetItem::EXPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid2' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end2' => ChangeSetItem::IMPLICITLY,
             ]
         );
 
@@ -136,7 +140,11 @@ class ChangeSetTest extends SapphireTest
         $this->assertChangeSetLooksLike(
             $cs,
             [
-            ChangeSetTest\BaseObject::class.'.base' => ChangeSetItem::EXPLICITLY
+                ChangeSetTest\BaseObject::class . '.base' => ChangeSetItem::EXPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid2' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end2' => ChangeSetItem::IMPLICITLY,
             ]
         );
     }
@@ -156,7 +164,11 @@ class ChangeSetTest extends SapphireTest
         $this->assertChangeSetLooksLike(
             $cs,
             [
-            ChangeSetTest\BaseObject::class.'.base' => ChangeSetItem::EXPLICITLY
+                ChangeSetTest\BaseObject::class . '.base' => ChangeSetItem::EXPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid2' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end2' => ChangeSetItem::IMPLICITLY,
             ]
         );
 
@@ -169,8 +181,11 @@ class ChangeSetTest extends SapphireTest
         $this->assertChangeSetLooksLike(
             $cs,
             [
-            ChangeSetTest\BaseObject::class.'.base' => ChangeSetItem::EXPLICITLY,
-            ChangeSetTest\EndObject::class.'.end1' => ChangeSetItem::IMPLICITLY
+                ChangeSetTest\BaseObject::class . '.base' => ChangeSetItem::EXPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid2' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end2' => ChangeSetItem::IMPLICITLY,
             ]
         );
 
@@ -212,13 +227,17 @@ class ChangeSetTest extends SapphireTest
         $this->assertChangeSetLooksLike(
             $cs,
             [
-            ChangeSetTest\BaseObject::class.'.base' => ChangeSetItem::EXPLICITLY
+                ChangeSetTest\BaseObject::class . '.base' => ChangeSetItem::EXPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid2' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end1' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end2' => ChangeSetItem::IMPLICITLY,
             ]
         );
         $this->assertTrue($cs->isSynced());
 
-        $end = $this->objFromFixture(ChangeSetTest\EndObject::class, 'end1');
-        $end->Baz = 3;
+        $end = $this->objFromFixture(ChangeSetTest\MidObject::class, 'mid1');
+        $end->BaseID = null;
         $end->write();
         $this->assertFalse($cs->isSynced());
 
@@ -227,8 +246,9 @@ class ChangeSetTest extends SapphireTest
         $this->assertChangeSetLooksLike(
             $cs,
             [
-            ChangeSetTest\BaseObject::class.'.base' => ChangeSetItem::EXPLICITLY,
-            ChangeSetTest\EndObject::class.'.end1' => ChangeSetItem::IMPLICITLY
+                ChangeSetTest\BaseObject::class . '.base' => ChangeSetItem::EXPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid2' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end2' => ChangeSetItem::IMPLICITLY,
             ]
         );
         $this->assertTrue($cs->isSynced());
@@ -487,7 +507,9 @@ class ChangeSetTest extends SapphireTest
         $this->assertChangeSetLooksLike(
             $changeset,
             [
-            ChangeSetTest\BaseObject::class.'.base' => ChangeSetItem::EXPLICITLY
+                ChangeSetTest\BaseObject::class . '.base' => ChangeSetItem::EXPLICITLY,
+                ChangeSetTest\MidObject::class . '.mid2' => ChangeSetItem::IMPLICITLY,
+                ChangeSetTest\EndObject::class . '.end2' => ChangeSetItem::IMPLICITLY,
             ]
         );
 

--- a/tests/php/ChangeSetTest.yml
+++ b/tests/php/ChangeSetTest.yml
@@ -1,6 +1,8 @@
 SilverStripe\Versioned\Tests\ChangeSetTest\BaseObject:
   base:
     Foo: 1
+  base2:
+    Foo: 3
 SilverStripe\Versioned\Tests\ChangeSetTest\EndObject:
   end1:
     Baz: 1
@@ -19,3 +21,5 @@ SilverStripe\Versioned\Tests\ChangeSetTest\MidObject:
     Bar: 2
     Base: =>SilverStripe\Versioned\Tests\ChangeSetTest\BaseObject.base
     End: =>SilverStripe\Versioned\Tests\ChangeSetTest\EndObject.end2
+  mid3:
+    Base: =>SilverStripe\Versioned\Tests\ChangeSetTest\BaseObject.base2


### PR DESCRIPTION
Regardless of whether they have been published

So implicit items are only removed if it is no longer implicitly included.