### PR TITLE
API Don’t unpublish owners when unpublishing children

### DIFF
--- a/tests/php/VersionedOwnershipTest/Subclass.php
+++ b/tests/php/VersionedOwnershipTest/Subclass.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\Versioned\Tests\VersionedOwnershipTest;
 
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\Versioned\Tests\VersionedOwnershipTest;
 
 /**
  * Object which:


### PR DESCRIPTION
API Introduce new hasPublishedOwners() method to toggle warnings prior to unpublish
Fixes #25