### PR TITLE
Expose as vendor module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "silverstripe/versioned",
     "description": "SilverStripe Versioned component",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "homepage": "http://silverstripe.org",
     "license": "BSD-3-Clause",
     "keywords": [
@@ -19,7 +19,8 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4@dev"
+        "silverstripe/framework": "^4@dev",
+        "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/7405
Merge after https://github.com/silverstripe/silverstripe-framework/pull/7395

Manually tested by publishing a page.

Test (after merging the framework pull request):

```
composer config repositories.versioned vcs https://github.com/open-sausages/silverstripe-versioned.git
composer require "silverstripe/versioned:dev-pulls/1/vendorise-me-baby as 1.0.x-dev"
```