### PR TITLE
ENHANCEMENT Allow extensions to clarify change type for versioned objects

### DIFF
--- a/src/ChangeSetItem.php
+++ b/src/ChangeSetItem.php
@@ -147,14 +147,16 @@ class ChangeSetItem extends DataObject implements Thumbnail
 
         // Version comparisons
         if ($draftVersion == $liveVersion) {
-            return self::CHANGE_NONE;
+            $type = self::CHANGE_NONE;
         } elseif (!$liveVersion) {
-            return self::CHANGE_CREATED;
+            $type = self::CHANGE_CREATED;
         } elseif (!$draftVersion) {
-            return self::CHANGE_DELETED;
+            $type = self::CHANGE_DELETED;
         } else {
-            return self::CHANGE_MODIFIED;
+            $type = self::CHANGE_MODIFIED;
         }
+        $this->extend('updateChangeType', $type, $draftVersion, $liveVersion);
+        return $type;
     }
 
     /**


### PR DESCRIPTION
Use case: Localised dataobjects may need to declare themselves as `CHANGED` if they are unpublished in the current locale, but are published in some other locale. An additional locale-gnostic check must be made within the extension to ChangeSetItem.