### PR TITLE
FIX Don’t override ItemRequest if already versioned

### DIFF
--- a/src/VersionedGridFieldDetailForm.php
+++ b/src/VersionedGridFieldDetailForm.php
@@ -24,17 +24,9 @@ class VersionedGridFieldDetailForm extends Extension
         if ($record
             && $record->has_extension(Versioned::class)
             && $record->config()->get('versioned_gridfield_extensions')
+            && (!$class || !is_subclass_of($class, VersionedGridFieldItemRequest::class))
         ) {
-            // don't override custom classes if they already subclass this
-            if (!$class) {
-                $class = VersionedGridFieldItemRequest::class;
-
-                return;
-            }
-
-            if (!is_subclass_of($class, VersionedGridFieldItemRequest::class)) {
-                $class = VersionedGridFieldItemRequest::class;
-            }
+            $class = VersionedGridFieldItemRequest::class;
         }
     }
 }

--- a/src/VersionedGridFieldDetailForm.php
+++ b/src/VersionedGridFieldDetailForm.php
@@ -20,12 +20,21 @@ class VersionedGridFieldDetailForm extends Extension
      */
     public function updateItemRequestClass(&$class, $gridField, $record, $requestHandler)
     {
-        // Conditionally use a versioned item handler
+        // Conditionally use a versioned item handler if it doesn't already have one.
         if ($record
             && $record->has_extension(Versioned::class)
             && $record->config()->get('versioned_gridfield_extensions')
         ) {
-            $class = VersionedGridFieldItemRequest::class;
+            // don't override custom classes if they already subclass this
+            if (!$class) {
+                $class = VersionedGridFieldItemRequest::class;
+
+                return;
+            }
+
+            if (!is_subclass_of($class, VersionedGridFieldItemRequest::class)) {
+                $class = VersionedGridFieldItemRequest::class;
+            }
         }
     }
 }


### PR DESCRIPTION
If a developer customises the ItemRequest don’t override it as long as it is already a versioned item hander.