### PR TITLE
Add code coverage whitelist to ensure stubs are not covered

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,4 +6,12 @@ Requires PHPUnit ^5.7
 	<testsuite name="Default">
 		<directory>tests/php</directory>
     </testsuite>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+            <exclude>
+                <directory suffix=".php">tests/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Currently the test stubs are included in code coverage reports, see: https://codecov.io/gh/silverstripe/silverstripe-versioned/tree/master/tests/php

Adding a standard whitelist to exclude the tests dir