### PR TITLE
API Upgrade to PHPUnit 7, increase minimum PHP version to 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,14 @@ before_script:
 
 # Install composer
   - composer validate
-  - composer install --prefer-source
   - composer require silverstripe/recipe-core:2.x-dev --no-update
-  - composer update
-
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:3.x-dev --prefer-dist; fi
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:3.x-dev --no-update; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/php; fi
   - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
-  - if [[ $PHPCS_TEST ]]; then composer validate; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,11 @@ before_script:
 
 # Install composer
   - composer validate
-  - composer install --prefer-dist
-  - composer require silverstripe/recipe-core:2.x-dev silverstripe/admin:2.x-dev --prefer-dist --no-update
+  - composer install --prefer-source
+  - composer require silverstripe/recipe-core:2.x-dev --no-update
   - composer update
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
+
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:3.x-dev --prefer-dist; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env: DB=PGSQL PHPUNIT_TEST=1 PHPCS_TEST=1
-    - php: 7.0
-      env: DB=MYSQL PHPUNIT_TEST=1
     - php: 7.1
+      env: DB=PGSQL PHPUNIT_TEST=1 PHPCS_TEST=1
+    - php: 7.1
+      env: DB=MYSQL PHPUNIT_TEST=1
+    - php: 7.2
       env: DB=MYSQL PDO=1 PHPUNIT_COVERAGE_TEST=1
 
 before_script:
@@ -27,7 +27,7 @@ before_script:
 # Install composer
   - composer validate
   - composer install --prefer-dist
-  - composer require silverstripe/recipe-core:2.0.x-dev silverstripe/admin:2.0.x-dev --prefer-dist --no-update
+  - composer require silverstripe/recipe-core:2.x-dev silverstripe/admin:2.x-dev --prefer-dist --no-update
   - composer update
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^7@dev",
         "silverstripe/admin": "^2"
     },
     "extra": {

--- a/tests/php/ChangeSetTest.php
+++ b/tests/php/ChangeSetTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Versioned\Tests;
 
 use BadMethodCallException;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit_Framework_ExpectationFailedException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SilverStripe\Dev\SapphireTest;
@@ -72,7 +73,7 @@ class ChangeSetTest extends SapphireTest
                 }
             }
 
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new ExpectationFailedException(
                 'Change set didn\'t include expected item',
                 new ComparisonFailure(
                     ['Class' => $class, 'ID' => $objectID, 'Added' => $mode],
@@ -93,11 +94,12 @@ class ChangeSetTest extends SapphireTest
                     'ChangeType' => $item->getChangeType()
                 ];
             }
-            throw new PHPUnit_Framework_ExpectationFailedException(
+            throw new ExpectationFailedException(
                 'Change set included items that weren\'t expected',
                 new ComparisonFailure([], $extra, '', print_r($extra, true))
             );
         }
+        $this->assertTrue(true, 'No exceptions were thrown during assertion process');
     }
 
     public function testAddObject()

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -16,7 +16,6 @@ use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Versioned\ChangeSet;
-use SilverStripe\Versioned\Tests\VersionedTest\SingleStage;
 use SilverStripe\Versioned\Versioned;
 
 class VersionedTest extends SapphireTest
@@ -150,10 +149,8 @@ class VersionedTest extends SapphireTest
         $obj->ExtraField = 'Foo'; // ensure that child version table gets written
         $obj->write();
         $class = VersionedTest\TestObject::class;
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            "Can't find {$class}#{$obj->ID} in stage Live"
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage("Can't find {$class}#{$obj->ID} in stage Live");
 
         // Fail publishing from live to stage
         $obj->copyVersionToStage(Versioned::LIVE, Versioned::DRAFT);
@@ -1177,7 +1174,7 @@ class VersionedTest extends SapphireTest
         $this->resetDBSchema(true);
         $testData = new VersionedTest\RelatedWithoutversion();
         $testData->NewField = 'Test';
-        $testData->write();
+        $this->assertGreaterThan(0, $testData->write(), 'Failed to successfully write object');
     }
 
     public function testCanView()


### PR DESCRIPTION
See silverstripe/silverstripe-framework#7653

Requires silverstripe/silverstripe-framework#7716

The extra assertions are because the tests originally don't assert anything, which PHPUnit 7.x treats as a "risky" test.