### PR TITLE
BUG Prevent nested permissions from breaking recursive publishing

### DIFF
--- a/src/ChangeSetItem.php
+++ b/src/ChangeSetItem.php
@@ -239,9 +239,6 @@ class ChangeSetItem extends DataObject implements Thumbnail
         }
 
         // Logical checks prior to publish
-        if (!$this->canPublish()) {
-            throw new Exception("The current member does not have permission to publish this ChangeSetItem.");
-        }
         if ($this->VersionBefore || $this->VersionAfter) {
             throw new BadMethodCallException("This ChangeSetItem has already been published");
         }
@@ -356,6 +353,11 @@ class ChangeSetItem extends DataObject implements Thumbnail
      */
     public function canPublish($member = null)
     {
+        // Implicitly added items allow publish
+        if ($this->Added === self::IMPLICITLY) {
+            return true;
+        }
+
         // Check canMethod to invoke on object
         switch ($this->getChangeType()) {
             case static::CHANGE_DELETED: {

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -1487,14 +1487,13 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
     /**
      * Publishes this object to Live, but doesn't publish owned objects.
      *
+     * User code should call {@see canPublish()} prior to invoking this method.
+     *
      * @return bool True if publish was successful
      */
     public function publishSingle()
     {
         $owner = $this->owner;
-        if (!$owner->canPublish()) {
-            return false;
-        }
         if ($this->isPublished()) {
             // get the last published version
             $baseClass = $owner->baseClass();
@@ -1587,36 +1586,29 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
     /**
      * Removes the record from both live and stage
      *
+     * User code should call {@see canArchive()} prior to invoking this method.
+     *
      * @return bool Success
      */
     public function doArchive()
     {
         $owner = $this->owner;
-        if (!$owner->canArchive()) {
-            return false;
-        }
-
         $owner->invokeWithExtensions('onBeforeArchive', $this);
         $owner->deleteFromChangeSets();
         $owner->doUnpublish();
         $owner->deleteFromStage(static::DRAFT);
         $owner->invokeWithExtensions('onAfterArchive', $this);
-
         return true;
     }
 
     /**
-     * Remove this item from any changesets
+     * Remove this item from any changesets.
      *
      * @return bool
      */
     public function deleteFromChangeSets()
     {
         $owner = $this->owner;
-        if (!$owner->canArchive()) {
-            return false;
-        }
-
         $ids = [$owner->ID];
         if ($owner->hasMethod('getDescendantIDList')) {
             $ids = array_merge($ids, $owner->getDescendantIDList());
@@ -1631,15 +1623,13 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
     /**
      * Removes this record from the live site
      *
+     * User code should call {@see canUnpublish()} prior to invoking this method.
+     *
      * @return bool Flag whether the unpublish was successful
      */
     public function doUnpublish()
     {
         $owner = $this->owner;
-        if (!$owner->canUnpublish()) {
-            return false;
-        }
-
         // Skip if this record isn't saved
         if (!$owner->isInDB()) {
             return false;
@@ -1688,15 +1678,13 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
     /**
      * Revert the draft changes: replace the draft content with the content on live
      *
+     * User code should call {@see canRevertToLive()} prior to invoking this method.
+     *
      * @return bool True if the revert was successful
      */
     public function doRevertToLive()
     {
         $owner = $this->owner;
-        if (!$owner->canRevertToLive()) {
-            return false;
-        }
-
         $owner->invokeWithExtensions('onBeforeRevertToLive');
         $owner->copyVersionToStage(static::LIVE, static::DRAFT, false);
         $owner->invokeWithExtensions('onAfterRevertToLive');

--- a/tests/php/ChangeSetTest.php
+++ b/tests/php/ChangeSetTest.php
@@ -11,6 +11,7 @@ use SilverStripe\Versioned\ChangeSet;
 use SilverStripe\Versioned\ChangeSetItem;
 use SilverStripe\Versioned\Tests\ChangeSetTest\BaseObject;
 use SilverStripe\Versioned\Tests\ChangeSetTest\MidObject;
+use SilverStripe\Versioned\Tests\ChangeSetTest\Permissions;
 use SilverStripe\Versioned\Versioned;
 
 /**
@@ -28,6 +29,16 @@ class ChangeSetTest extends SapphireTest
         ChangeSetTest\EndObjectChild::class,
         ChangeSetTest\UnversionedObject::class,
     ];
+
+    protected function tearDown()
+    {
+        // Reset overridden permissions
+        foreach ($this->getExtraDataObjects() as $dataObjectClass) {
+            /** @var Permissions $dataObjectClass */
+            $dataObjectClass::reset();
+        }
+        parent::tearDown();
+    }
 
     /**
      * Automatically publish all objects
@@ -213,7 +224,7 @@ class ChangeSetTest extends SapphireTest
             $endItem->ReferencedBy()->column("ID")
         );
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 [
                     'Added' => ChangeSetItem::EXPLICITLY,
@@ -252,7 +263,7 @@ class ChangeSetTest extends SapphireTest
         $this->assertEquals(ChangeSetItem::CHANGE_DELETED, $mid2Item->getChangeType());
         $this->assertEquals(ChangeSetItem::CHANGE_DELETED, $end2Item->getChangeType());
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 [
                     'Added' => ChangeSetItem::EXPLICITLY,
@@ -324,10 +335,6 @@ class ChangeSetTest extends SapphireTest
         $this->logOut();
         $this->assertFalse($changeSet->canPublish());
 
-        // campaign admin only permission doesn't grant publishing rights
-        $this->logInWithPermission('CMS_ACCESS_CampaignAdmin');
-        $this->assertFalse($changeSet->canPublish());
-
         // With model publish permissions only publish is allowed
         $this->logInWithPermission('PERM_canPublish');
         $this->assertTrue($changeSet->canPublish());
@@ -340,6 +347,52 @@ class ChangeSetTest extends SapphireTest
             ]
         );
         $this->assertTrue($changeSet->canPublish());
+
+        // campaign admin only permission doesn't grant publishing rights
+        $this->logInWithPermission('CMS_ACCESS_CampaignAdmin');
+        $this->assertFalse($changeSet->canPublish());
+
+        // Test that you can still publish a changeset, even if canPublish()
+        // returns false (e.g. externally rather than internally enforced)
+        $changeSet->publish();
+    }
+
+    /**
+     * Test that nested can publish correctly respects implicit / explicit items
+     */
+    public function testCanPublishNested()
+    {
+        // Create changeset containing all items (unpublished)
+        $this->logInWithPermission('PERM_canPublish');
+        $changeSet = new ChangeSet();
+        $changeSet->write();
+        /** @var ChangeSetTest\BaseObject $base */
+        $base = $this->objFromFixture(ChangeSetTest\BaseObject::class, 'base');
+        /** @var ChangeSetTest\MidObject $mid1 */
+        $mid1 = $this->objFromFixture(ChangeSetTest\MidObject::class, 'mid1');
+        $changeSet->addObject($base);
+        $changeSet->addObject($mid1);
+        $changeSet->sync();
+        $this->assertEquals(5, $changeSet->Changes()->count());
+
+        // With model publish permissions only publish is allowed
+        $this->assertTrue($changeSet->canPublish());
+
+        // setting canPublish = false on any implicit items in the changeset doesn't
+        // deny publishing permissions
+        /** @var ChangeSetTest\MidObject $mid2 */
+        $mid2 = $this->objFromFixture(ChangeSetTest\MidObject::class, 'mid2');
+        $mid2->setCan('canPublish', false);
+        $this->assertTrue($changeSet->canPublish());
+
+        // Setting canPublish = false on any explicit item in the changeset
+        // does deny publishing permissions
+        $mid1->setCan('canPublish', false);
+        $this->assertFalse($changeSet->canPublish());
+
+        // Test that you can still publish a changeset, even if canPublish()
+        // returns false (e.g. externally rather than internally enforced)
+        $changeSet->publish();
     }
 
     public function testHasChanges()

--- a/tests/php/ChangeSetTest/Permissions.php
+++ b/tests/php/ChangeSetTest/Permissions.php
@@ -14,6 +14,8 @@ use SilverStripe\Security\Permission;
  */
 trait Permissions
 {
+    public static $can_overrides = [];
+
     public function canEdit($member = null)
     {
         return $this->can(__FUNCTION__, $member);
@@ -41,10 +43,34 @@ trait Permissions
 
     public function can($perm, $member = null, $context = [])
     {
+        // Check object overrides
+        if (isset(static::$can_overrides[$this->ID][$perm])) {
+            return static::$can_overrides[$this->ID][$perm];
+        }
+
         $perms = [
             "PERM_{$perm}",
             'CAN_ALL',
         ];
         return Permission::checkMember($member, $perms);
+    }
+
+    /**
+     * Set can override
+     *
+     * @param string $perm
+     * @param bool $can
+     */
+    public function setCan($perm, $can)
+    {
+        static::$can_overrides[$this->ID][$perm] = (bool)$can;
+    }
+
+    /**
+     * Reset overrides
+     */
+    public static function reset()
+    {
+        static::$can_overrides = [];
     }
 }


### PR DESCRIPTION
ENHANCEMENT Modify permission checks to require outside invocation instead of verifying internally (ref: https://docs.silverstripe.org/en/4/developer_guides/model/permissions/)

Fixes #112 
Fixes https://github.com/silverstripe/silverstripe-framework/issues/7837

Note: It would be good for a @silverstripe/core-team to confirm my thinking regarding the permissions (see the link above). I feel that we should stick with the convention of requiring user code to invoke those permission checks, rather than internally failing if any are denied, causing exceptions.