### PR TITLE
BUG Fix doRollbackTo() writing old / unsaved version over restored version

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2325,7 +2325,6 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
         $owner = $this->owner;
         $owner->extend('onBeforeRollback', $version);
         $owner->copyVersionToStage($version, static::DRAFT, true);
-        $owner->writeWithoutVersion();
         $owner->extend('onAfterRollback', $version);
     }
 

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -307,6 +307,7 @@ class VersionedTest extends SapphireTest
 
     public function testRollbackTo()
     {
+        /** @var VersionedTest\AnotherSubclass $page1 */
         $page1 = $this->objFromFixture(VersionedTest\AnotherSubclass::class, 'subclass1');
         $page1->Content = 'orig';
         $page1->write();
@@ -318,6 +319,7 @@ class VersionedTest extends SapphireTest
         $page1->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
         $changedVersion = $page1->Version;
 
+        $page1->Content = 'should be discarded';
         $page1->doRollbackTo($origVersion);
         $page1 = Versioned::get_one_by_stage(
             VersionedTest\TestObject::class,


### PR DESCRIPTION
See warning on PHPDoc

Fixes https://github.com/tractorcow/silverstripe-fluent/issues/313