### PR TITLE
NEW Allow CMS breadcrumb badge to be extended

### DIFF
--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -37,6 +37,8 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
                 $status['class'],
                 $status['title']
             ));
+            $this->extend('updateBadge', $badge);
+
             /** @var ArrayData $lastItem */
             $lastItem = $items->last();
             $lastItem->setField('Extra', $badge);

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -30,6 +30,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
     {
         $items = parent::Breadcrumbs($unlinked);
         $status = $this->getRecordStatus();
+        $badge = null;
         if ($status) {
             // Generate badge
             $badge = DBField::create_field('HTMLFragment', sprintf(
@@ -37,12 +38,15 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
                 $status['class'],
                 $status['title']
             ));
-            $this->extend('updateBadge', $badge);
+        }
+        $this->extend('updateBadge', $badge);
 
+        if ($badge) {
             /** @var ArrayData $lastItem */
             $lastItem = $items->last();
             $lastItem->setField('Extra', $badge);
         }
+
         return $items;
     }
 


### PR DESCRIPTION
Allows other modules to push badges to the breadcrumbs as well as versioned, which would overwrite anything that was already set. NB: other modules must append or prepend whatever was there first (from this module).

Closes silverstripe/silverstripe-admin#439