### PR TITLE
FIX Resolve Published version field to Versioned_Version::Published() correctly

### DIFF
--- a/src/GraphQL/Extensions/DataObjectScaffolderExtension.php
+++ b/src/GraphQL/Extensions/DataObjectScaffolderExtension.php
@@ -54,6 +54,9 @@ class DataObjectScaffolderExtension extends Extension
                     ],
                     'Published' => [
                         'type' => Type::boolean(),
+                        'resolve' => function ($obj) {
+                            return $obj->Published();
+                        }
                     ]
                 ];
                 // Remove this recursive madness.


### PR DESCRIPTION
Before this change `Published` in the Versions list is always returning null. My assumption is that it's not mapping to the property because the prop name is `WasPublished`, which is what `Versioned_Version::Published()` checks and return the value of.