### PR TITLE
FIX Add missing published state filter

### DIFF
--- a/src/GraphQL/Resolvers/ApplyVersionFilters.php
+++ b/src/GraphQL/Resolvers/ApplyVersionFilters.php
@@ -109,6 +109,10 @@ class ApplyVersionFilters
                     $conditions[] = "\"{$liveTable}\".\"ID\" IS NULL AND \"{$draftTable}\".\"ID\" IS NOT NULL";
                 }
 
+                if (in_array('published', $statuses)) {
+                    $conditions[] = "\"{$liveTable}\".\"ID\" IS NOT NULL";
+                }
+
                 // Validate that all statuses have been handled
                 if (empty($conditions) || count($statuses) !== count($conditions)) {
                     throw new InvalidArgumentException("Invalid statuses provided");


### PR DESCRIPTION
When writing a query like this:

```
query readOnePage{
  readOnePage(Versioning:{
    Mode: STATUS
    Status:[DRAFT,PUBLISHED]
  }, ID:2){
```

You get an error: `"message": "Invalid statuses provided",`

This PR adds the condition for "published" which was missing.