### PR TITLE
FIX Duplicate only what we want

### DIFF
--- a/src/RecursivePublishable.php
+++ b/src/RecursivePublishable.php
@@ -318,7 +318,7 @@ class RecursivePublishable extends DataExtension
     public function onBeforeDuplicate($original, &$doWrite, &$relations)
     {
         // If relations to duplicate are declared (or forced off) don't rewrite
-        if ($relations || $relations === false) {
+        if ($relations !== null) {
             return;
         }
 


### PR DESCRIPTION
In SilverStripe core 4.1 line, when we duplicate a record we have the
option of trying to duplicate only many_many, or not. 4.1 extends this
logic to specify any of the relationship types (in a legacy support mode
that is marked deprecated to be fair). This way any old module
that sepcifies 'many_many' for the relations parameter (as was the old
default) in theory keeps working.

The issue is that not all models define a `many_many` relationship - and
when this happens the resulting list of reltationship names to duplicate
is an empty array. This would be fine, but then Versioned here goes and
writes into that reference passed array, every single relationship defined
on the model. So the end result is actually that any old module that
manages it's own relations on duplication ends up with two of everything
in said defined relationship.

This is easily recitfied by making the comparison more strict, rather than
either 'trueish' or specificlly `false`, we'll short-circuit on anything
that isn't `null`.

Resolves #127 