### PR TITLE
NEW Add isLiveVersion and isLatestDraftVersion to Versioned and GraphQL DataObject scaffolding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       env: DB=MYSQL PHPUNIT_TEST=1
     - php: 7.1
       env: DB=MYSQL PDO=1 PHPUNIT_COVERAGE_TEST=1
+    - php: 7.2
+      env: DB=MYSQL PHPUNIT_TEST=1
 
 before_script:
 # Init PHP

--- a/src/GraphQL/Extensions/DataObjectScaffolderExtension.php
+++ b/src/GraphQL/Extensions/DataObjectScaffolderExtension.php
@@ -57,7 +57,19 @@ class DataObjectScaffolderExtension extends Extension
                         'resolve' => function ($obj) {
                             return $obj->Published();
                         }
-                    ]
+                    ],
+                    'LiveVersion' => [
+                        'type' => Type::boolean(),
+                        'resolve' => function ($obj) {
+                            return $obj->LiveVersion();
+                        }
+                    ],
+                    'LatestDraftVersion' => [
+                        'type' => Type::boolean(),
+                        'resolve' => function ($obj) {
+                            return $obj->LatestDraftVersion();
+                        }
+                    ],
                 ];
                 // Remove this recursive madness.
                 unset($coreFields['Versions']);

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2445,6 +2445,38 @@ SQL
     }
 
     /**
+     * Returns whether the current record's version is the current live/published version
+     *
+     * @return bool
+     */
+    public function isLiveVersion()
+    {
+        $id = $this->owner->ID ?: $this->owner->OldID;
+        if (!$id || !$this->isPublished()) {
+            return false;
+        }
+
+        $liveVersionNumber = static::get_versionnumber_by_stage($this->owner, Versioned::LIVE, $id);
+        return $liveVersionNumber === $this->owner->Version;
+    }
+
+    /**
+     * Returns whether the current record's version is the current draft/modified version
+     *
+     * @return bool
+     */
+    public function isLatestDraftVersion()
+    {
+        $id = $this->owner->ID ?: $this->owner->OldID;
+        if (!$id || !$this->isOnDraft()) {
+            return false;
+        }
+
+        $draftVersionNumber = static::get_versionnumber_by_stage($this->owner, Versioned::DRAFT, $id);
+        return $draftVersionNumber === $this->owner->Version;
+    }
+
+    /**
      * Check if this record exists on live
      *
      * @return bool

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2457,7 +2457,7 @@ SQL
         }
 
         $liveVersionNumber = static::get_versionnumber_by_stage($this->owner, Versioned::LIVE, $id);
-        return $liveVersionNumber === $this->owner->Version;
+        return (int) $liveVersionNumber === (int) $this->owner->Version;
     }
 
     /**
@@ -2473,7 +2473,7 @@ SQL
         }
 
         $draftVersionNumber = static::get_versionnumber_by_stage($this->owner, Versioned::DRAFT, $id);
-        return $draftVersionNumber === $this->owner->Version;
+        return (int) $draftVersionNumber === (int) $this->owner->Version;
     }
 
     /**

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2457,7 +2457,7 @@ SQL
         }
 
         $liveVersionNumber = static::get_versionnumber_by_stage($this->owner, Versioned::LIVE, $id);
-        return (int) $liveVersionNumber === (int) $this->owner->Version;
+        return $liveVersionNumber == $this->owner->Version;
     }
 
     /**
@@ -2473,7 +2473,7 @@ SQL
         }
 
         $draftVersionNumber = static::get_versionnumber_by_stage($this->owner, Versioned::DRAFT, $id);
-        return (int) $draftVersionNumber === (int) $this->owner->Version;
+        return $draftVersionNumber == $this->owner->Version;
     }
 
     /**

--- a/src/Versioned_Version.php
+++ b/src/Versioned_Version.php
@@ -87,6 +87,26 @@ class Versioned_Version extends ViewableData
     }
 
     /**
+     * True if the current version is the current live/published version
+     *
+     * @return boolean
+     */
+    public function LiveVersion()
+    {
+        return $this->object->isLiveVersion();
+    }
+
+    /**
+     * True if the current version is the latest draft/modified version
+     *
+     * @return boolean
+     */
+    public function LatestDraftVersion()
+    {
+        return $this->object->isLatestDraftVersion();
+    }
+
+    /**
      * Traverses to a field referenced by relationships between data objects, returning the value
      * The path to the related field is specified with dot separated syntax (eg: Parent.Child.Child.FieldName)
      *

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -1414,7 +1414,7 @@ class VersionedTest extends SapphireTest
         // published page
         $publishedPage = new VersionedTest\TestObject();
         $publishedPage->write();
-        $publishedPage->copyVersionToStage('Stage', 'Live');
+        $publishedPage->writeToStage(Versioned::LIVE);
         $this->assertTrue($publishedPage->isOnDraft());
         $this->assertTrue($publishedPage->isPublished());
         $this->assertTrue($publishedPage->isLiveVersion());
@@ -1425,7 +1425,7 @@ class VersionedTest extends SapphireTest
         // published page, deleted from stage
         $deletedFromDraftPage = new VersionedTest\TestObject();
         $deletedFromDraftPage->write();
-        $deletedFromDraftPage->copyVersionToStage('Stage', 'Live');
+        $deletedFromDraftPage->writeToStage(Versioned::LIVE);
         $deletedFromDraftPage->deleteFromStage('Stage');
         $this->assertFalse($deletedFromDraftPage->isArchived());
         $this->assertFalse($deletedFromDraftPage->isOnDraft());
@@ -1437,7 +1437,7 @@ class VersionedTest extends SapphireTest
         // published page, deleted from live
         $deletedFromLivePage = new VersionedTest\TestObject();
         $deletedFromLivePage->write();
-        $deletedFromLivePage->copyVersionToStage('Stage', 'Live');
+        $deletedFromLivePage->writeToStage(Versioned::LIVE);
         $deletedFromLivePage->deleteFromStage('Live');
         $this->assertFalse($deletedFromLivePage->isArchived());
         $this->assertTrue($deletedFromLivePage->isOnDraft());
@@ -1449,7 +1449,7 @@ class VersionedTest extends SapphireTest
         // published page, deleted from both stages
         $deletedFromAllStagesPage = new VersionedTest\TestObject();
         $deletedFromAllStagesPage->write();
-        $deletedFromAllStagesPage->copyVersionToStage('Stage', 'Live');
+        $deletedFromAllStagesPage->writeToStage(Versioned::LIVE);
         $deletedFromAllStagesPage->doArchive();
         $this->assertTrue($deletedFromAllStagesPage->isArchived());
         $this->assertFalse($deletedFromAllStagesPage->isOnDraft());
@@ -1461,7 +1461,7 @@ class VersionedTest extends SapphireTest
         // published page, modified
         $modifiedOnDraftPage = new VersionedTest\TestObject();
         $modifiedOnDraftPage->write();
-        $modifiedOnDraftPage->copyVersionToStage('Stage', 'Live');
+        $modifiedOnDraftPage->writeToStage(Versioned::LIVE);
         $modifiedOnDraftPage->Content = 'modified';
         $modifiedOnDraftPage->write();
         $this->assertFalse($modifiedOnDraftPage->isArchived());

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -1417,6 +1417,7 @@ class VersionedTest extends SapphireTest
         $publishedPage->copyVersionToStage('Stage', 'Live');
         $this->assertTrue($publishedPage->isOnDraft());
         $this->assertTrue($publishedPage->isPublished());
+        $this->assertTrue($publishedPage->isLiveVersion());
         $this->assertFalse($publishedPage->isOnDraftOnly());
         $this->assertFalse($publishedPage->isOnLiveOnly());
         $this->assertFalse($publishedPage->isModifiedOnDraft());
@@ -1464,6 +1465,8 @@ class VersionedTest extends SapphireTest
         $modifiedOnDraftPage->Content = 'modified';
         $modifiedOnDraftPage->write();
         $this->assertFalse($modifiedOnDraftPage->isArchived());
+        $this->assertFalse($modifiedOnDraftPage->isLiveVersion());
+        $this->assertTrue($modifiedOnDraftPage->isLatestDraftVersion());
         $this->assertTrue($modifiedOnDraftPage->isOnDraft());
         $this->assertTrue($modifiedOnDraftPage->isPublished());
         $this->assertFalse($modifiedOnDraftPage->isOnDraftOnly());


### PR DESCRIPTION
This surfaces whether each version is the current live version and the current/latest draft or modified version.

Required for #37