### PR TITLE
BUG Ensure extra fields have correct casting

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -168,6 +168,21 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
     ];
 
     /**
+     * Ensure versioned records cast extra fields properly
+     *
+     * @config
+     * @var array
+     */
+    private static $casting = [
+        "RecordID" => "Int",
+        "WasPublished" => "Boolean",
+        "WasDeleted" => "Boolean",
+        "WasDraft" => "Boolean",
+        "AuthorID" => "Int",
+        "PublisherID" => "Int"
+    ];
+
+    /**
      * @var array
      * @config
      */


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-versioned/issues/124

Once merged, merge up to master to fix cms master tests.

The problem is that the `Was*` fields were cast to default_cast (varchar), which treats "0"(string) as non-falsey. PDO connections use strings for int results, hence the tests would pass on non-pdo connectors.

Casting to boolean correctly ensures the correct cast.