### PR TITLE
ENHANCEMENT Ensure invalid stage values are thrown as exceptions

### DIFF
--- a/src/ReadingMode.php
+++ b/src/ReadingMode.php
@@ -28,12 +28,14 @@ class ReadingMode
         switch ($parts[0]) {
             case 'Archive':
                 $archiveStage = isset($parts[2]) ? $parts[2] : Versioned::DRAFT;
+                self::validateStage($archiveStage);
                 return [
                     'Versioned.mode' => 'archive',
                     'Versioned.date' => $parts[1],
                     'Versioned.stage' => $archiveStage,
                 ];
             case 'Stage':
+                self::validateStage($parts[1]);
                 return [
                     'Versioned.mode' => 'stage',
                     'Versioned.stage' => $parts[1],
@@ -88,7 +90,7 @@ class ReadingMode
             ? $query['archiveDate']
             : null;
 
-        // Check stage
+        // Check stage (ignore invalid stages)
         $stage = null;
         if (isset($query['stage']) && strcasecmp($query['stage'], Versioned::DRAFT) === 0) {
             $stage = Versioned::DRAFT;
@@ -131,17 +133,31 @@ class ReadingMode
         switch ($parts[0]) {
             case 'Archive':
                 $archiveStage = isset($parts[2]) ? $parts[2] : Versioned::DRAFT;
+                self::validateStage($archiveStage);
                 return [
                     'archiveDate' => $parts[1],
                     'stage' => $archiveStage,
                 ];
             case 'Stage':
+                self::validateStage($parts[1]);
                 return [
                     'stage' => $parts[1],
                 ];
             default:
                 // Unsupported mode
                 return null;
+        }
+    }
+
+    /**
+     * Validate the stage is valid, throwing an exception if it's not
+     *
+     * @param string $stage
+     */
+    public static function validateStage($stage)
+    {
+        if (!in_array($stage, [Versioned::LIVE, Versioned::DRAFT])) {
+            throw new InvalidArgumentException("Invalid stage name \"{$stage}\"");
         }
     }
 }

--- a/tests/php/ReadingModeTest.php
+++ b/tests/php/ReadingModeTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Versioned\Tests;
 
+use InvalidArgumentException;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Versioned\ReadingMode;
 
@@ -142,6 +143,25 @@ class ReadingModeTest extends SapphireTest
                 ],
                 'archiveDate=2017-11-15+11%3A31%3A42&stage=Live',
             ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestInvalidStage
+     * @param string $stage
+     */
+    public function testInvalidStage($stage)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ReadingMode::validateStage($stage);
+    }
+
+    public function provideTestInvalidStage()
+    {
+        return [
+            [''],
+            ['stage'],
+            ['bob'],
         ];
     }
 }


### PR DESCRIPTION
Reference; https://github.com/dnadesign/silverstripe-elemental/pull/215

This change will prevent invalid stages creeping into the current mode, causing hard-to-track down errors.