### PR TITLE
Only add versioned buttons when owned objects actually exist

### DIFF
--- a/src/RecursivePublishable.php
+++ b/src/RecursivePublishable.php
@@ -151,14 +151,6 @@ class RecursivePublishable extends DataExtension
 
         $ownedRelationships = $this->owner->config()->get('owns') ?: [];
         foreach ($ownedRelationships as $relationship) {
-            if (!$this->owner->hasMethod($relationship)) {
-                trigger_error(sprintf(
-                    "Invalid ownership of \"%s\" on class \"%s\"",
-                    $relationship,
-                    get_class($this)
-                ), E_USER_WARNING);
-                continue;
-            }
             /* @var DataObject|SS_List $result */
             $result = $this->owner->{$relationship}();
             if ($result->exists()) {

--- a/src/RecursivePublishable.php
+++ b/src/RecursivePublishable.php
@@ -11,6 +11,8 @@ use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\Queries\SQLUpdate;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\ORM\Tests\MySQLDatabaseTest\Data;
 
 /**
  * Provides owns / owned_by and recursive publishing API for all objects.
@@ -135,6 +137,36 @@ class RecursivePublishable extends DataExtension
     {
         // Find objects in these relationships
         return $this->owner->findRelatedObjects('owns', $recursive, $list);
+    }
+
+    /**
+     * Returns true if the record has any owned relationships that exist
+     * @return bool
+     */
+    public function hasOwned()
+    {
+        if (!$this->owner->isInDB()) {
+            return false;
+        }
+
+        $ownedRelationships = $this->owner->config()->get('owns') ?: [];
+        foreach ($ownedRelationships as $relationship) {
+            if (!$this->owner->hasMethod($relationship)) {
+                trigger_error(sprintf(
+                    "Invalid ownership of \"%s\" on class \"%s\"",
+                    $relationship,
+                    get_class($this)
+                ), E_USER_WARNING);
+                continue;
+            }
+            /* @var DataObject|SS_List $result */
+            $result = $this->owner->{$relationship}();
+            if ($result->exists()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -64,7 +64,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
         $ownerRecursivePublishes = !$ownerIsStaged
             && $record
             && $record->hasExtension(RecursivePublishable::class)
-            && $record->hasOwned();
+            && $record->config()->get('owns');
 
         // Add extra actions prior to extensions so that these can be modified too
         if ($ownerIsStaged) {
@@ -350,15 +350,5 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             __CLASS__ . '.BUTTONAPPLYCHANGES',
             'Apply changes'
         ))->addExtraClass('btn-primary font-icon-save');
-
-        $actions->push(LiteralField::create(
-            'warning',
-            '<span class="btn actions-warning font-icon-info-circled">'
-            . _t(
-                __CLASS__ . '.PUBLISHITEMSWARNING',
-                'Draft/modified items will be published'
-            )
-            . '</span>'
-        ));
     }
 }

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -64,7 +64,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
         $ownerRecursivePublishes = !$ownerIsStaged
             && $record
             && $record->hasExtension(RecursivePublishable::class)
-            && $record->config()->get('owns');
+            && $record->findOwned()->exists();
 
         // Add extra actions prior to extensions so that these can be modified too
         if ($ownerIsStaged) {
@@ -346,7 +346,6 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
         if (!$this->record->ID) {
             return;
         }
-
         $saveAction->setTitle(_t(
             __CLASS__ . '.BUTTONAPPLYCHANGES',
             'Apply changes'

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -64,7 +64,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
         $ownerRecursivePublishes = !$ownerIsStaged
             && $record
             && $record->hasExtension(RecursivePublishable::class)
-            && $record->findOwned()->exists();
+            && $record->hasOwned();
 
         // Add extra actions prior to extensions so that these can be modified too
         if ($ownerIsStaged) {

--- a/tests/php/VersionedGridFieldItemRequestTest.php
+++ b/tests/php/VersionedGridFieldItemRequestTest.php
@@ -126,8 +126,8 @@ class VersionedGridFieldItemRequestTest extends SapphireTest
         /** @var LiteralField $warningField */
         $actions = $form->Actions();
         $warningField = $actions->fieldByName('warning');
-        $this->assertInstanceOf(LiteralField::class, $warningField);
-        $this->assertRegExp('/will be published/', $warningField->getContent());
+        // Warning was removed as part of #154 ... it may be brough back later
+        $this->assertNull($warningField);
     }
 
     protected function createItemRequestForObject(DataObject $obj)

--- a/tests/php/VersionedOwnershipTest.php
+++ b/tests/php/VersionedOwnershipTest.php
@@ -4,7 +4,13 @@ namespace SilverStripe\Versioned\Tests;
 
 use SilverStripe\Versioned\ChangeSet;
 use SilverStripe\Versioned\ChangeSetItem;
+use SilverStripe\Versioned\Tests\VersionedOwnershipTest\Attachment;
+use SilverStripe\Versioned\Tests\VersionedOwnershipTest\Banner;
+use SilverStripe\Versioned\Tests\VersionedOwnershipTest\Image;
+use SilverStripe\Versioned\Tests\VersionedOwnershipTest\Related;
 use SilverStripe\Versioned\Tests\VersionedOwnershipTest\RelatedMany;
+use SilverStripe\Versioned\Tests\VersionedOwnershipTest\TestPage;
+use SilverStripe\Versioned\Tests\VersionedTest\Subclass;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -150,6 +156,27 @@ class VersionedOwnershipTest extends SapphireTest
             ],
             $related2->findOwned()
         );
+    }
+
+    public function testHasOwned()
+    {
+        $this->assertFalse(Subclass::create()->hasOwned(), 'hasOwned returns false on unwritten objects');
+
+        /** @var VersionedOwnershipTest\Subclass $subclass1 */
+        $subclass1 = $this->objFromFixture(VersionedOwnershipTest\Subclass::class, 'subclass1_published');
+        $this->assertTrue($subclass1->hasOwned());
+
+        /** @var VersionedOwnershipTest\Related $related1 */
+        $related1 = $this->objFromFixture(VersionedOwnershipTest\Related::class, 'related1');
+
+        // Test when the list is empty
+        $related1->Attachments()->removeAll();
+        $this->assertFalse($related1->hasOwned(), 'hasOwned is false when relation is empty');
+
+        $banner = $this->objFromFixture(Banner::class, 'banner1_published');
+        $this->assertTrue($banner->hasOwned(), 'hasOwned is true when a has_one exists');
+        $banner->ImageID = 0;
+        $this->assertFalse($banner->hasOwned(), 'hasOwned is false when a has_one does not exist');
     }
 
     /**


### PR DESCRIPTION
Now that `FileTracking` is applied to all dataobjects, this returns a lot of false positives, creating an ominous "Apply changes (draft /modified items will be published)" warning. This is bad UX and is also stuffing up Behat tests, e.g. https://travis-ci.org/silverstripe/silverstripe-framework/jobs/379449536#L917

`findOwned()` is not very performant, but open to suggestions.

Parent issue https://github.com/silverstripe/silverstripe-framework/issues/8029