### PR TITLE
Add versioned graphql types via extension instead of direct YAML

### DIFF
--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -22,11 +22,6 @@ SilverStripe\GraphQL\Scaffolding\Scaffolders\OperationScaffolder:
     copyToStage: SilverStripe\Versioned\GraphQL\Operations\CopyToStage
     publish: SilverStripe\Versioned\GraphQL\Operations\Publish
     unpublish: SilverStripe\Versioned\GraphQL\Operations\Unpublish
-SilverStripe\GraphQL\Controller:
-  schema:
-    types:
-      VersionedStage: SilverStripe\Versioned\GraphQL\Types\VersionedStage
-      VersionedStatus: SilverStripe\Versioned\GraphQL\Types\VersionedStatus
-      VersionedQueryMode: SilverStripe\Versioned\GraphQL\Types\VersionedQueryMode
-      VersionedInputType: SilverStripe\Versioned\GraphQL\Types\VersionedInputType
-      CopyToStageInputType: SilverStripe\Versioned\GraphQL\Types\CopyToStageInputType
+SilverStripe\GraphQL\Manager:
+  extensions:
+    - SilverStripe\Versioned\GraphQL\Extensions\ManagerExtension

--- a/src/GraphQL/Extensions/ManagerExtension.php
+++ b/src/GraphQL/Extensions/ManagerExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\Versioned\GraphQL\Extensions;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Versioned\GraphQL\Types\CopyToStageInputType;
+use SilverStripe\Versioned\GraphQL\Types\VersionedInputType;
+use SilverStripe\Versioned\GraphQL\Types\VersionedQueryMode;
+use SilverStripe\Versioned\GraphQL\Types\VersionedStage;
+use SilverStripe\Versioned\GraphQL\Types\VersionedStatus;
+
+class ManagerExtension extends Extension
+{
+    /**
+     * Adds the versioned types to all schemas
+     *
+     * @param $config
+     */
+    public function updateConfig(&$config)
+    {
+        if (!isset($config['types'])) {
+            $config['types'] = [];
+        }
+
+        $config['types']['VersionedStage'] = VersionedStage::class;
+        $config['types']['VersionedStatus'] = VersionedStatus::class;
+        $config['types']['VersionedQueryMode'] = VersionedQueryMode::class;
+        $config['types']['VersionedInputType'] = VersionedInputType::class;
+        $config['types']['CopyToStageInputType'] = CopyToStageInputType::class;
+    }
+}

--- a/src/GraphQL/Operations/Publish.php
+++ b/src/GraphQL/Operations/Publish.php
@@ -38,7 +38,7 @@ class Publish extends PublishOperation
      * @param Member $member
      * @return boolean
      */
-    protected function checkPermission(DataObjectInterface $obj, Member $member)
+    protected function checkPermission(DataObjectInterface $obj, Member $member = null)
     {
         /** @var Versioned $obj */
         return $obj->canPublish($member);

--- a/src/GraphQL/Operations/PublishOperation.php
+++ b/src/GraphQL/Operations/PublishOperation.php
@@ -99,7 +99,7 @@ abstract class PublishOperation extends MutationScaffolder implements OperationR
         ];
     }
 
-    abstract protected function checkPermission(DataObjectInterface $obj, Member $member);
+    abstract protected function checkPermission(DataObjectInterface $obj, Member $member = null);
 
     abstract protected function doMutation(DataObjectInterface $obj);
 

--- a/src/GraphQL/Operations/Unpublish.php
+++ b/src/GraphQL/Operations/Unpublish.php
@@ -38,7 +38,7 @@ class Unpublish extends PublishOperation
      * @param Member $member
      * @return boolean
      */
-    protected function checkPermission(DataObjectInterface $obj, Member $member)
+    protected function checkPermission(DataObjectInterface $obj, Member $member = null)
     {
         /** @var Versioned|DataObject $obj */
         return $obj->canUnpublish($member);


### PR DESCRIPTION
In adherence to new multi-schema work.

Resolves: https://github.com/silverstripe/silverstripe-graphql/issues/158