### PR TITLE
Fix escaping for back link

### DIFF
--- a/src/VersionedHTTPMiddleware.php
+++ b/src/VersionedHTTPMiddleware.php
@@ -9,6 +9,7 @@ use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Core\Convert;
 use SilverStripe\Security\Security;
+use SilverStripe\ORM\FieldType\DBField;
 
 /**
  * Initialises the versioned stage when a request is made.
@@ -61,6 +62,9 @@ class VersionedHTTPMiddleware implements HTTPMiddleware
         );
 
         // Force output since RequestFilter::preRequest doesn't support response overriding
-        return Security::permissionFailure(null, $permissionMessage);
+        return Security::permissionFailure(
+            null,
+            DBField::create_field('HTMLText', $permissionMessage)
+        );
     }
 }


### PR DESCRIPTION
Currently the back link is not correctly escaped as HTML Text.

Example: 
![screen shot 2018-07-13 at 2 17 04 pm](https://user-images.githubusercontent.com/101629/42668977-72cb98de-86a7-11e8-87f0-6675890c5543.png)
