### PR TITLE
FIX Draft content requiring login message now correctly renders HTML link

### DIFF
--- a/src/VersionedHTTPMiddleware.php
+++ b/src/VersionedHTTPMiddleware.php
@@ -8,6 +8,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Core\Convert;
+use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Security\Security;
 
 /**
@@ -53,12 +54,12 @@ class VersionedHTTPMiddleware implements HTTPMiddleware
 
         // Build error message
         $link = Convert::raw2xml(Controller::join_links(Director::baseURL(), $request->getURL(), "?stage=Live"));
-        $permissionMessage = _t(
+        $permissionMessage = DBField::create_field('HTMLFragment', _t(
             __CLASS__.'.DRAFT_SITE_ACCESS_RESTRICTION',
             'You must log in with your CMS password in order to view the draft or archived content. '
             . '<a href="{link}">Click here to go back to the published site.</a>',
-            [ 'link' => $link ]
-        );
+            ['link' => $link]
+        ));
 
         // Force output since RequestFilter::preRequest doesn't support response overriding
         return Security::permissionFailure(null, $permissionMessage);


### PR DESCRIPTION
Resolves https://github.com/silverstripe/silverstripe-framework/issues/8322