### PR TITLE
FIX Do not update LeftAndMain link with Stage param

### DIFF
--- a/src/VersionedStateExtension.php
+++ b/src/VersionedStateExtension.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Versioned;
 
+use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Extension;
@@ -46,6 +47,11 @@ class VersionedStateExtension extends Extension
         $queryargs = ReadingMode::toQueryString($readingMode);
         if (!$queryargs) {
             return;
+        }
+
+        // Don't touch Admin/CMS links
+        if (class_exists(LeftAndMain::class) && $this->getOwner() instanceof LeftAndMain) {
+            return false;
         }
 
         // Decorate

--- a/src/VersionedStateExtension.php
+++ b/src/VersionedStateExtension.php
@@ -51,7 +51,7 @@ class VersionedStateExtension extends Extension
 
         // Don't touch Admin/CMS links
         if (class_exists(LeftAndMain::class) && $this->getOwner() instanceof LeftAndMain) {
-            return false;
+            return;
         }
 
         // Decorate

--- a/tests/php/VersionedStateExtensionTest.php
+++ b/tests/php/VersionedStateExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Versioned\Tests;
 
+use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Versioned\VersionedStateExtension;
@@ -60,5 +61,20 @@ class VersionedStateExtensionTest extends SapphireTest
         $obj1Live = Versioned::get_by_stage(VersionedStateExtensionTest\LinkableObject::class, Versioned::LIVE)
             ->byID($obj1ID);
         $this->assertEquals('item/myobject/', $obj1Live->Link());
+    }
+
+    public function testDontUpdateLeftAndMainLinks()
+    {
+        $controller = new LeftAndMain();
+
+        $liveClientConfig = $controller->getClientConfig();
+        Versioned::set_stage(Versioned::DRAFT);
+        $stageClientConfig = $controller->getClientConfig();
+
+        $this->assertEquals(
+            $liveClientConfig,
+            $stageClientConfig,
+            'LeftAndMain Client config should not be affected by versionned stage.'
+        );
     }
 }


### PR DESCRIPTION
Add a condition so we don't try to add Stage URL param to LeftAndMain links.

Fixes https://github.com/silverstripe/silverstripe-admin/issues/607