### PR TITLE
FIX Detection of extendedCan now works preventing infinite loops in unit tests

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -1442,7 +1442,7 @@ SQL
         $owner = $this->owner;
 
         // Skip if invoked by extendedCan()
-        if (func_num_args() > 4) {
+        if (func_num_args() > 1) {
             return null;
         }
 

--- a/tests/php/GridFieldRestoreActionTest.php
+++ b/tests/php/GridFieldRestoreActionTest.php
@@ -64,16 +64,15 @@ class GridFieldRestoreActionTest extends SapphireTest
 
     public function testDontShowRestoreButtons()
     {
-        if (Security::getCurrentUser()) {
-            Security::setCurrentUser(null);
-        }
+        $this->logOut();
+
         $content = new CSSContentParser($this->gridField->FieldHolder());
         // Check that there are content
-        $this->assertEquals(4, count($content->getBySelector('.ss-gridfield-item')));
+        $this->assertCount(4, $content->getBySelector('.ss-gridfield-item'));
         // Make sure that there are no restore buttons
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($content->getBySelector('.action-restore')),
+            $content->getBySelector('.action-restore'),
             'Restore buttons should not show when not logged in.'
         );
     }


### PR DESCRIPTION
GridFieldRestoreActionTest::testDontShowRestoreButtons via TestObject::canRestoreToDraft was causing infinite loops and exceeding memory limits. The Versioned::canRestoreToDraft method calls itself via $owner->extendedCan(canRestoreToDraft, $member), but it never passes more than two arguments. This patch fixes the loose recursion check.

This should get the SS5 tests green.