### PR TITLE
FIX: Performance optimisation for draft pages in treeview

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2282,6 +2282,13 @@ SQL
             return self::$cache_versionnumber[$baseClass][$stage][$id] ?: null;
         }
 
+        // if the cache was marked as "complete" then we know the record is missing, just return null
+        // this is used for treeview optimisation to avoid unnecessary re-requests for draft pages
+        if (!empty(self::$cache_versionnumber[$baseClass][$stage]['_complete'])) {
+            return null;
+        }
+
+
         // get version as performance-optimized SQL query (gets called for each record in the sitetree)
         $version = DB::prepared_query(
             "SELECT \"Version\" FROM \"$stageTable\" WHERE \"ID\" = ?",
@@ -2320,6 +2327,13 @@ SQL
         if (!Config::inst()->get(static::class, 'prepopulate_versionnumber_cache')) {
             return;
         }
+
+        /** @var Versioned|DataObject $singleton */
+        $singleton = DataObject::singleton($class);
+        $baseClass = $singleton->baseClass();
+        $baseTable = $singleton->baseTable();
+        $stageTable = $singleton->stageTable($baseTable, $stage);
+
         $filter = "";
         $parameters = [];
         if ($idList) {
@@ -2334,13 +2348,12 @@ SQL
             }
             $filter = 'WHERE "ID" IN (' . DB::placeholders($idList) . ')';
             $parameters = $idList;
-        }
 
-        /** @var Versioned|DataObject $singleton */
-        $singleton = DataObject::singleton($class);
-        $baseClass = $singleton->baseClass();
-        $baseTable = $singleton->baseTable();
-        $stageTable = $singleton->stageTable($baseTable, $stage);
+        // If we are caching IDs for _all_ records then we can mark this cache as "complete" and in the case of a cache-miss
+        // no subsequent call is necessary
+        } else {
+            self::$cache_versionnumber[$baseClass][$stage] = [ '_complete' => true ];
+        }
 
         $versions = DB::prepared_query("SELECT \"ID\", \"Version\" FROM \"$stageTable\" $filter", $parameters)->map();
 

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2278,16 +2278,15 @@ SQL
         }
 
         // cached call
-        if ($cache && isset(self::$cache_versionnumber[$baseClass][$stage][$id])) {
-            return self::$cache_versionnumber[$baseClass][$stage][$id] ?: null;
+        if ($cache) {
+            if (isset(self::$cache_versionnumber[$baseClass][$stage][$id])) {
+                return self::$cache_versionnumber[$baseClass][$stage][$id] ?: null;
+            } elseif (isset(self::$cache_versionnumber[$baseClass][$stage]['_complete'])) {
+                // if the cache was marked as "complete" then we know the record is missing, just return null
+                // this is used for treeview optimisation to avoid unnecessary re-requests for draft pages
+                return null;
+            }
         }
-
-        // if the cache was marked as "complete" then we know the record is missing, just return null
-        // this is used for treeview optimisation to avoid unnecessary re-requests for draft pages
-        if (!empty(self::$cache_versionnumber[$baseClass][$stage]['_complete'])) {
-            return null;
-        }
-
 
         // get version as performance-optimized SQL query (gets called for each record in the sitetree)
         $version = DB::prepared_query(

--- a/tests/php/VersionedNumberCacheTest.php
+++ b/tests/php/VersionedNumberCacheTest.php
@@ -4,13 +4,17 @@ namespace SilverStripe\Versioned\Tests;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Versioned\Versioned;
-use Page;
+use SilverStripe\Versioned\Tests\VersionedTest\TestObject;
 
 /**
  * @internal Only test the right values are returned, not that the cache is actually used.
  */
 class VersionedNumberCacheTest extends SapphireTest
 {
+
+    public static $extra_dataobjects = [
+        VersionedTest\TestObject::class
+    ];
 
     /**
      * @var int
@@ -30,7 +34,7 @@ class VersionedNumberCacheTest extends SapphireTest
         parent::setUpBeforeClass();
 
         // Initialise our dummy object
-        $obj = Page::create(['Title' => 'Initial version']);
+        $obj = TestObject::create(['Title' => 'Initial version']);
         $obj->write();
         self::$publishedID = $obj->ID;
 
@@ -46,7 +50,7 @@ class VersionedNumberCacheTest extends SapphireTest
         $draftVersion = $obj->Version;
 
         // This object won't ne publish
-        $draftOnly = Page::create(['Title' => 'Draft Only object']);
+        $draftOnly = TestObject::create(['Title' => 'Draft Only object']);
         $draftOnly->write();
         self::$draftOnlyID = $draftOnly->ID;
 
@@ -60,7 +64,7 @@ class VersionedNumberCacheTest extends SapphireTest
     public function setUp()
     {
         parent::setUp();
-        Page::singleton()->flushCache();
+        TestObject::singleton()->flushCache();
     }
 
     public function cacheDataProvider()
@@ -81,12 +85,12 @@ class VersionedNumberCacheTest extends SapphireTest
      */
     public function testVersionNumberCache($stage, $ID, $cache, $expected)
     {
-        $actual = Versioned::get_versionnumber_by_stage(Page::class, $stage, self::${$ID}, $cache);
+        $actual = Versioned::get_versionnumber_by_stage(TestObject::class, $stage, self::${$ID}, $cache);
         $this->assertEquals(self::$expectedVersions[$expected], $actual);
 
         if ($cache) {
             // When cahing is eanbled, try re-accessing version number to make sure the cache returns the same value
-            $actual = Versioned::get_versionnumber_by_stage(Page::class, $stage, self::${$ID}, $cache);
+            $actual = Versioned::get_versionnumber_by_stage(TestObject::class, $stage, self::${$ID}, $cache);
             $this->assertEquals(self::$expectedVersions[$expected], $actual);
         }
     }
@@ -96,8 +100,8 @@ class VersionedNumberCacheTest extends SapphireTest
      */
     public function testPrepopulatedVersionNumberCache($stage, $ID, $cache, $expected)
     {
-        Versioned::prepopulate_versionnumber_cache(Page::class, $stage);
-        $actual = Versioned::get_versionnumber_by_stage(Page::class, $stage, self::${$ID}, $cache);
+        Versioned::prepopulate_versionnumber_cache(TestObject::class, $stage);
+        $actual = Versioned::get_versionnumber_by_stage(TestObject::class, $stage, self::${$ID}, $cache);
         $this->assertEquals(self::$expectedVersions[$expected], $actual);
     }
 }

--- a/tests/php/VersionedNumberCacheTest.php
+++ b/tests/php/VersionedNumberCacheTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Versioned\Versioned;
+use Page;
+
+/**
+ * @internal Only test the right values are returned, not that the cache is actually used.
+ */
+class VersionedNumberCacheTest extends SapphireTest
+{
+
+    /**
+     * @var int
+     */
+    private static $publishedID;
+
+    /**
+     * @var int
+     */
+    private static $draftOnlyID;
+
+    private static $expectedVersions = [ ];
+
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        // Initialise our dummy object
+        $obj = Page::create(['Title' => 'Initial version']);
+        $obj->write();
+        self::$publishedID = $obj->ID;
+
+        // Create our live version
+        $obj->Title = 'This will be our live version';
+        $obj->write();
+        $obj->publishSingle();
+        $liveVersion = $obj->Version;
+
+        // Create our draft version
+        $obj->Title = 'This will be our draft version';
+        $obj->write();
+        $draftVersion = $obj->Version;
+
+        // This object won't ne publish
+        $draftOnly = Page::create(['Title' => 'Draft Only object']);
+        $draftOnly->write();
+        self::$draftOnlyID = $draftOnly->ID;
+
+        self::$expectedVersions = [
+            'liveVersion' => $liveVersion,
+            'draftVersion' => $draftVersion,
+            'null' => null
+        ];
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+        Page::singleton()->flushCache();
+    }
+
+    public function cacheDataProvider()
+    {
+        return [
+            [Versioned::DRAFT, 'publishedID', false, 'draftVersion'],
+            [Versioned::DRAFT, 'publishedID', true, 'draftVersion'],
+            [Versioned::LIVE, 'publishedID', false, 'liveVersion'],
+            [Versioned::LIVE, 'publishedID', true, 'liveVersion'],
+            [Versioned::LIVE, 'draftOnlyID', false, 'null'],
+            [Versioned::LIVE, 'draftOnlyID', true, 'null'],
+        ];
+    }
+
+
+    /**
+     * @dataProvider cacheDataProvider
+     */
+    public function testVersionNumberCache($stage, $ID, $cache, $expected)
+    {
+        $actual = Versioned::get_versionnumber_by_stage(Page::class, $stage, self::${$ID}, $cache);
+        $this->assertEquals(self::$expectedVersions[$expected], $actual);
+
+        if ($cache) {
+            // When cahing is eanbled, try re-accessing version number to make sure the cache returns the same value
+            $actual = Versioned::get_versionnumber_by_stage(Page::class, $stage, self::${$ID}, $cache);
+            $this->assertEquals(self::$expectedVersions[$expected], $actual);
+        }
+    }
+
+    /**
+     * @dataProvider cacheDataProvider
+     */
+    public function testPrepopulatedVersionNumberCache($stage, $ID, $cache, $expected)
+    {
+        Versioned::prepopulate_versionnumber_cache(Page::class, $stage);
+        $actual = Versioned::get_versionnumber_by_stage(Page::class, $stage, self::${$ID}, $cache);
+        $this->assertEquals(self::$expectedVersions[$expected], $actual);
+    }
+}

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -1491,45 +1491,4 @@ class VersionedTest extends SapphireTest
         $this->assertFalse($modifiedOnDraftPage->isOnLiveOnly());
         $this->assertTrue($modifiedOnDraftPage->isModifiedOnDraft());
     }
-
-    public function testVersionNumberCache()
-    {
-        $pageOne = $this->objFromFixture(VersionedTest\TestObject::class, 'page1');
-        $pageOneVersionNum = Versioned::get_versionnumber_by_stage(
-            VersionedTest\TestObject::class,
-            Versioned::DRAFT,
-            $pageOne->ID,
-            false
-        );
-
-        $this->assertEquals(
-            $pageOneVersionNum,
-            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, $pageOne->ID, true),
-            'get_versionnumber_by_stage should return the right version number when the value is not cached.'
-        );
-        $this->assertEquals(
-            $pageOneVersionNum,
-            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, $pageOne->ID, true),
-            'get_versionnumber_by_stage should return the right version number when the value is cached.'
-        );
-        $this->assertNull(
-            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, 999, false),
-            'get_versionnumber_by_stage should return null when fetching a version number for un unexisting object.'
-        );
-
-        $this->assertNull(
-            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, 999, true),
-            'get_versionnumber_by_stage should return null when fetching a version number for unchached unexisting object'
-        );
-        $this->assertNull(
-            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, 999, true),
-            'get_versionnumber_by_stage should return null when fetching a version number for cached unexisting object'
-        );
-
-        Versioned::prepopulate_versionnumber_cache(VersionedTest\TestObject::class, Versioned::DRAFT);
-        $this->assertNull(
-            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, 888, true),
-            'get_versionnumber_by_stage should return null when fetching a version number for unexisting object with prepopulate_versionnumber_caching'
-        );
-    }
 }

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -1491,4 +1491,45 @@ class VersionedTest extends SapphireTest
         $this->assertFalse($modifiedOnDraftPage->isOnLiveOnly());
         $this->assertTrue($modifiedOnDraftPage->isModifiedOnDraft());
     }
+
+    public function testVersionNumberCache()
+    {
+        $pageOne = $this->objFromFixture(VersionedTest\TestObject::class, 'page1');
+        $pageOneVersionNum = Versioned::get_versionnumber_by_stage(
+            VersionedTest\TestObject::class,
+            Versioned::DRAFT,
+            $pageOne->ID,
+            false
+        );
+
+        $this->assertEquals(
+            $pageOneVersionNum,
+            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, $pageOne->ID, true),
+            'get_versionnumber_by_stage should return the right version number when the value is not cached.'
+        );
+        $this->assertEquals(
+            $pageOneVersionNum,
+            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, $pageOne->ID, true),
+            'get_versionnumber_by_stage should return the right version number when the value is cached.'
+        );
+        $this->assertNull(
+            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, 999, false),
+            'get_versionnumber_by_stage should return null when fetching a version number for un unexisting object.'
+        );
+
+        $this->assertNull(
+            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, 999, true),
+            'get_versionnumber_by_stage should return null when fetching a version number for unchached unexisting object'
+        );
+        $this->assertNull(
+            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, 999, true),
+            'get_versionnumber_by_stage should return null when fetching a version number for cached unexisting object'
+        );
+
+        Versioned::prepopulate_versionnumber_cache(VersionedTest\TestObject::class, Versioned::DRAFT);
+        $this->assertNull(
+            Versioned::get_versionnumber_by_stage(VersionedTest\TestObject::class, Versioned::DRAFT, 888, true),
+            'get_versionnumber_by_stage should return null when fetching a version number for unexisting object with prepopulate_versionnumber_caching'
+        );
+    }
 }


### PR DESCRIPTION
When draft pages are rendered in the treeview, an attempt to look up
their live Version # is made. This leads to a cache miss and a
subsequent query for each record.

This change marks a cache as “complete” when all records of a given
stage are pre-cached. This will suppress the record-specific query
in the case of a cache miss.

# Parent issue
* silverstripe/silverstripe-cms#2250