### PR TITLE
FIX: Use Hierarchy::prepopulateTreeDataCache() in CMS.

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2312,6 +2312,20 @@ SQL
     }
 
     /**
+     * Hook into {@link Hierarchy::prepopulateTreeDataCache}.
+     *
+     * @param DataList $recordList The list of records to prepopulate caches for. Null for all records.
+     * @param array $options A map of hints about what should be cached. "numChildrenMethod" and
+     *                       "childrenMethod" are allowed keys.
+     */
+    public function onPrepopulateTreeDataCache(DataList $recordList = null, array $options = [])
+    {
+        $idList = $recordList ? $recordList->column('ID') : null;
+        self::prepopulate_versionnumber_cache($this->owner->baseClass(), Versioned::DRAFT, $idList);
+        self::prepopulate_versionnumber_cache($this->owner->baseClass(), Versioned::LIVE, $idList);
+    }
+
+    /**
      * Pre-populate the cache for Versioned::get_versionnumber_by_stage() for
      * a list of record IDs, for more efficient database querying.  If $idList
      * is null, then every record will be pre-cached.

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2314,13 +2314,14 @@ SQL
     /**
      * Hook into {@link Hierarchy::prepopulateTreeDataCache}.
      *
-     * @param DataList $recordList The list of records to prepopulate caches for. Null for all records.
+     * @param DataList|array $recordList The list of records to prepopulate caches for. Null for all records.
      * @param array $options A map of hints about what should be cached. "numChildrenMethod" and
      *                       "childrenMethod" are allowed keys.
      */
-    public function onPrepopulateTreeDataCache(DataList $recordList = null, array $options = [])
+    public function onPrepopulateTreeDataCache($recordList = null, array $options = [])
     {
-        $idList = $recordList ? $recordList->column('ID') : null;
+        $idList = is_array($recordList) ? $recordList :
+            ($recordList instanceof DataList ? $recordList->column('ID') : null);
         self::prepopulate_versionnumber_cache($this->owner->baseClass(), Versioned::DRAFT, $idList);
         self::prepopulate_versionnumber_cache($this->owner->baseClass(), Versioned::LIVE, $idList);
     }

--- a/tests/php/VersionedNumberCacheTest.php
+++ b/tests/php/VersionedNumberCacheTest.php
@@ -100,7 +100,7 @@ class VersionedNumberCacheTest extends SapphireTest
      */
     public function testPrepopulatedVersionNumberCache($stage, $ID, $cache, $expected)
     {
-        Versioned::prepopulate_versionnumber_cache(TestObject::class, $stage);
+        TestObject::singleton()->onPrepopulateTreeDataCache();
         $actual = Versioned::get_versionnumber_by_stage(TestObject::class, $stage, self::${$ID}, $cache);
         $this->assertEquals(self::$expectedVersions[$expected], $actual);
     }


### PR DESCRIPTION
Doesn't do anything without https://github.com/silverstripe/silverstripe-framework/pull/8395