### PR TITLE
fix inferReciprocalComponent called on unsaved

### DIFF
--- a/src/RecursivePublishable.php
+++ b/src/RecursivePublishable.php
@@ -199,18 +199,20 @@ class RecursivePublishable extends DataExtension
         $owner = $this->owner;
         $owners = $owner->findRelatedObjects('owned_by', false);
 
-        // Second pass: Find owners via reverse lookup list
-        foreach ($lookup as $ownedClass => $classLookups) {
-            // Skip owners of other objects
-            if (!is_a($this->owner, $ownedClass)) {
-                continue;
-            }
-            foreach ($classLookups as $classLookup) {
-                // Merge new owners into this object's owners
-                $ownerClass = $classLookup['class'];
-                $ownerRelation = $classLookup['relation'];
-                $result = $this->owner->inferReciprocalComponent($ownerClass, $ownerRelation);
-                $owner->mergeRelatedObjects($owners, $result);
+        // Second pass: Find owners via reverse lookup list if possible
+        if ($owner->ID) {
+            foreach ($lookup as $ownedClass => $classLookups) {
+                // Skip owners of other objects
+                if (!is_a($owner, $ownedClass)) {
+                    continue;
+                }
+                foreach ($classLookups as $classLookup) {
+                    // Merge new owners into this object's owners
+                    $ownerClass = $classLookup['class'];
+                    $ownerRelation = $classLookup['relation'];
+                    $result = $owner->inferReciprocalComponent($ownerClass, $ownerRelation);
+                    $owner->mergeRelatedObjects($owners, $result);
+                }
             }
         }
 

--- a/src/RecursivePublishable.php
+++ b/src/RecursivePublishable.php
@@ -200,7 +200,7 @@ class RecursivePublishable extends DataExtension
         $owners = $owner->findRelatedObjects('owned_by', false);
 
         // Second pass: Find owners via reverse lookup list if possible
-        if ($owner->ID) {
+        if ($owner->isInDB()) {
             foreach ($lookup as $ownedClass => $classLookups) {
                 // Skip owners of other objects
                 if (!is_a($owner, $ownedClass)) {


### PR DESCRIPTION
DataObject::inferReciprocalComponent  cannot be called on object without IDs. There is currently no checks if owner has a proper id, which could result on errors.
Also use $owner instead of $this->owner for consistency in the function.

to be honest, I'm not sure how I managed to do that, but this extra check cannot hurt in my opinion.