### PR TITLE
MINOR Bypass sync validation on ChangeSet when it just got built

### DIFF
--- a/src/ChangeSet.php
+++ b/src/ChangeSet.php
@@ -115,10 +115,13 @@ class ChangeSet extends DataObject
      *
      * User code should call {@see canPublish()} prior to invoking this method.
      *
-     * @throws Exception
+     * @throws BadMethodCallException ChangeSet has already been published or reverted.
+     * @throws ValidationException ChangeSet is not synced an can not be published.
+     * @param boolean $isSynced Whatever to assume the ChangeSet is synced. Only set this to true if the ChangetSet
+     * just got built. Defaults to false.
      * @return bool True if successful
      */
-    public function publish()
+    public function publish($isSynced = false)
     {
         // Logical checks prior to publish
         if ($this->State !== static::STATE_OPEN) {
@@ -126,7 +129,7 @@ class ChangeSet extends DataObject
                 "ChangeSet can't be published if it has been already published or reverted."
             );
         }
-        if (!$this->isSynced()) {
+        if (!$isSynced && !$this->isSynced()) {
             throw new ValidationException(
                 "ChangeSet does not include all necessary changes and cannot be published."
             );

--- a/src/RecursivePublishable.php
+++ b/src/RecursivePublishable.php
@@ -70,7 +70,7 @@ class RecursivePublishable extends DataExtension
         );
         $changeset->write();
         $changeset->addObject($this->owner);
-        return $changeset->publish();
+        return $changeset->publish(true);
     }
 
     /**

--- a/tests/php/ChangeSetTest.php
+++ b/tests/php/ChangeSetTest.php
@@ -10,6 +10,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\ChangeSet;
 use SilverStripe\Versioned\ChangeSetItem;
 use SilverStripe\Versioned\Tests\ChangeSetTest\BaseObject;
+use SilverStripe\Versioned\Tests\ChangeSetTest\ChangeSetSyncStub;
 use SilverStripe\Versioned\Tests\ChangeSetTest\MidObject;
 use SilverStripe\Versioned\Tests\ChangeSetTest\Permissions;
 use SilverStripe\Versioned\Versioned;
@@ -721,5 +722,14 @@ class ChangeSetTest extends SapphireTest
                 ChangeSetTest\EndObject::class . '.end2' => ChangeSetItem::IMPLICITLY,
             ]
         );
+    }
+
+    public function testIsSyncedCanBeSkipped()
+    {
+        $changeset = new ChangeSetSyncStub();
+
+        $changeset->publish(true);
+
+        $this->assertFalse($changeset->isSyncCalled, 'isSynced is skipped when providing truthy argument to publish');
     }
 }

--- a/tests/php/ChangeSetTest/ChangeSetSyncStub.php
+++ b/tests/php/ChangeSetTest/ChangeSetSyncStub.php
@@ -1,0 +1,15 @@
+<?php
+namespace SilverStripe\Versioned\Tests\ChangeSetTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Versioned\ChangeSet;
+
+class ChangeSetSyncStub extends ChangeSet implements TestOnly
+{
+    public $isSyncCalled = false;
+
+    public function isSynced()
+    {
+        $this->isSyncCalled = true;
+    }
+}


### PR DESCRIPTION
Provides tiny incy wincy performance boost when doing a publish recursive. Basically, if you just built a change set, you can safely assume it's in sync. So I added a flag to the publish method on the ChangeSet that allow you to bypass the sync validation.

# Parent Issue
* #189 