### PR TITLE
NEW Adding GraphQL operation scaffolder for rollbackRecursive on versioned objects

### DIFF
--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -22,6 +22,7 @@ SilverStripe\GraphQL\Scaffolding\Scaffolders\OperationScaffolder:
     copyToStage: SilverStripe\Versioned\GraphQL\Operations\CopyToStage
     publish: SilverStripe\Versioned\GraphQL\Operations\Publish
     unpublish: SilverStripe\Versioned\GraphQL\Operations\Unpublish
+    rollback: SilverStripe\Versioned\GraphQL\Operations\Rollback
 SilverStripe\GraphQL\Manager:
   extensions:
     - SilverStripe\Versioned\GraphQL\Extensions\ManagerExtension

--- a/src/GraphQL/Operations/CopyToStage.php
+++ b/src/GraphQL/Operations/CopyToStage.php
@@ -16,7 +16,11 @@ if (!class_exists(MutationScaffolder::class)) {
 }
 
 /**
- * A generic "create" operation for a DataObject.
+ * Scaffolds a "copy to stage" operation for DataObjects.
+ *
+ * copy[TypeName]ToStage(ID!, FromVersion!, FromStage!, ToStage!)
+ *
+ * @internal This is a low level API that might be removed in the future. Consider using the "rollback" mutation instead
  */
 class CopyToStage extends MutationScaffolder implements OperationResolver
 {

--- a/src/GraphQL/Operations/Rollback.php
+++ b/src/GraphQL/Operations/Rollback.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SilverStripe\Versioned\GraphQL\Operations;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use InvalidArgumentException;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\OperationResolver;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\MutationScaffolder;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+if (!class_exists(MutationScaffolder::class)) {
+    return;
+}
+
+/**
+ * Scaffolds a "rollback recursive" operation for DataObjects.
+ *
+ * rollback[TypeName](ID!, ToVersion!)
+ */
+class Rollback extends MutationScaffolder implements OperationResolver
+{
+    /**
+     * CreateOperationScaffolder constructor.
+     *
+     * @param string $dataObjectClass
+     */
+    public function __construct($dataObjectClass)
+    {
+        parent::__construct(null, null, $this, $dataObjectClass);
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        $name = parent::getName();
+        if ($name) {
+            return $name;
+        }
+
+        $typeName = $this->getTypeName();
+
+        return 'rollback' . ucfirst($typeName);
+    }
+
+    /**
+     * @param Manager $manager
+     * @return array
+     */
+    public function createDefaultArgs(Manager $manager)
+    {
+        return [
+            'ID' => [
+                'type' => Type::nonNull(Type::id()),
+                'description' => 'The object ID that needs to be rolled back'
+            ],
+            'ToVersion' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'The version of the object that should be rolled back to'
+            ],
+        ];
+    }
+
+    /**
+     * Invoked by the Executor class to resolve this mutation / query
+     * @see Executor
+     *
+     * @param mixed $object
+     * @param array $args
+     * @param mixed $context
+     * @param ResolveInfo $info
+     * @return mixed
+     */
+    public function resolve($object, array $args, $context, ResolveInfo $info)
+    {
+        // Get the args
+        $id = $args['ID'];
+        $rollbackVersion = $args['ToVersion'];
+
+        // Pull the latest version of the record
+        /** @var Versioned|DataObject $record */
+        $record = Versioned::get_latest_version($this->getDataObjectClass(), $id);
+
+        // Assert permission
+        $user = $context['currentUser'];
+        if (!$record->canEdit($user)) {
+            throw new InvalidArgumentException('Current user does not have permission to roll back this resource');
+        }
+
+        // Perform the rollback
+        $record = $record->rollbackRecursive($rollbackVersion);
+
+        return $record;
+    }
+}

--- a/tests/php/GraphQL/Operations/Rollback/FakeDataObjectStub.php
+++ b/tests/php/GraphQL/Operations/Rollback/FakeDataObjectStub.php
@@ -1,0 +1,36 @@
+<?php
+namespace SilverStripe\Versioned\Tests\GraphQL\Operations\Rollback;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+class FakeDataObjectStub extends DataObject implements TestOnly
+{
+    private static $table_name = 'VersionedGraphQLTest_DataObject_RollbackStub';
+
+    private static $db = [
+        'Name' => 'Varchar',
+        'Editable' => 'Boolean',
+    ];
+
+    private static $defaults = [
+        'Editable' => true,
+    ];
+
+    private static $extensions = [
+        Versioned::class,
+    ];
+
+    public static $rollbackCalled = false;
+
+    public function canEdit($member = null)
+    {
+        return $this->Editable;
+    }
+
+    public function rollbackRecursive($rollbackVersion)
+    {
+        self::$rollbackCalled = true;
+    }
+}

--- a/tests/php/GraphQL/Operations/RollbackTest.php
+++ b/tests/php/GraphQL/Operations/RollbackTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\GraphQL\Operations;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\Scaffolding\StaticSchema;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Security;
+use SilverStripe\Versioned\GraphQL\Operations\Rollback;
+use SilverStripe\Versioned\Tests\GraphQL\Operations\Rollback\FakeDataObjectStub;
+
+class RollbackTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    public static $extra_dataobjects = [
+        FakeDataObjectStub::class,
+    ];
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Current user does not have permission to roll back this resource
+     */
+    public function testRollbackCannotBePerformedWithoutEditPermission()
+    {
+        // Create a fake version of our stub
+        $stub = FakeDataObjectStub::create();
+        $stub->Name = 'First';
+        $stub->Editable = false;
+        $stub->write();
+
+        $this->doMutation($stub);
+    }
+
+    public function testRollbackRecursiveIsCalled()
+    {
+        // Create a fake version of our stub
+        $stub = FakeDataObjectStub::create();
+        $stub->Name = 'First';
+        $stub->write();
+
+        $this->doMutation($stub);
+
+        $this->assertTrue($stub::$rollbackCalled, 'RollbackRecursive was called');
+    }
+
+    protected function doMutation(DataObject $stub, $toVersion = 1, $member = null)
+    {
+        if (!$stub->isInDB()) {
+            $stub->write();
+        }
+
+        $stubClass = get_class($stub);
+        $typeName = StaticSchema::inst()->typeNameForDataObject($stubClass);
+        $manager = new Manager();
+        $manager->addType(new ObjectType(['name' => $typeName]));
+
+        $mutation = new Rollback($stubClass);
+        $scaffold = $mutation->scaffold($manager);
+        $this->assertInternalType('callable', $scaffold['resolve'], 'Resolve function is scaffolded correctly');
+
+        $args = [
+            'ID' => $stub->ID,
+            'ToVersion' => $toVersion,
+        ];
+
+        $scaffold['resolve'](
+            null,
+            $args,
+            [ 'currentUser' => $member ?: Security::getCurrentUser() ],
+            new ResolveInfo([])
+        );
+    }
+}


### PR DESCRIPTION
Fixes #190 . This is a NEW targetted at 1.3 because it's fixing silverstripe/silverstripe-cms#2326

I've also marked the "CopyToStage" mutation as internal because it's quite low level and probably won't do all that you would want.