### PR TITLE
DOCS Remove misleading comment about Versioned::writeWithoutVersion() acting on objects without versioning

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -1206,7 +1206,6 @@ SQL
 
     /**
      * Perform a write without affecting the version table.
-     * On objects without versioning.
      *
      * @return int The ID of the record
      */


### PR DESCRIPTION
This part of the docblock is misleading - since it's part of Versioned it inherently only applies to versioned objects.