### PR TITLE
FIX Implemented various options to improve archive query performance

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -686,7 +686,6 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
      */
     protected function promoteConditions(SQLSelect $baseQuery, SQLSelect $newQuery)
     {
-
     }
 
     /**

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -678,17 +678,6 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
     }
 
     /**
-     * Inspect a given query that's being "augmented" and determine any conditions that can be "promoted" to an inner
-     * join on the same table. This helps with performance
-     *
-     * @param SQLSelect $query
-     * @param SQLSelect $newQuery
-     */
-    protected function promoteConditions(SQLSelect $baseQuery, SQLSelect $newQuery)
-    {
-    }
-
-    /**
      * Indicates if a subquery filtering versioned records should apply as a condition instead of an inner join
      *
      * @param SQLSelect $baseQuery


### PR DESCRIPTION
This is a performance "fix" that should have no impact on the existing functionality.

This is a follow-up to #213 . There was concern in that PR that the solution we came up with (changing the non-correlated subquery to a correlated one) had too many performance concerns. The suggestion was provided to "promote" certain conditions from the outer query to the inner join. The only condition that can be promoted is a filter on the primary key of the base table. This PR adds that which adds a small performance improvement.

I've also re-added the functionality from #213 but it relies on a hook added in silverstripe/silverstripe-framework#8915 or a config setting. In my large project I found zero scenarios where the inner join was more performant than the condition - and it is ~5s (browsing to a page with `?archiveDate`) rather than ~200s.

I've edited this to reflect the new state of this PR - it was originally doing more "condition promoting" which was flawed logic.