### PR TITLE
MINOR: Add test to validate writeWithoutVersioned

### DIFF
--- a/tests/php/VersionedTest/TestObject.php
+++ b/tests/php/VersionedTest/TestObject.php
@@ -53,6 +53,11 @@ class TestObject extends DataObject implements TestOnly
         'Related' => RelatedWithoutversion::class,
     ];
 
+    /**
+     * Flag to trigger some optional behaviour for tests
+     */
+    public static $setNameWithoutVersionAfterPublish = null;
+
     public function canView($member = null)
     {
         $extended = $this->extendedCan(__FUNCTION__, $member);
@@ -60,5 +65,13 @@ class TestObject extends DataObject implements TestOnly
             return $extended;
         }
         return true;
+    }
+
+    public function onAfterPublish($original)
+    {
+        if (self::$setNameWithoutVersionAfterPublish !== null) {
+            $this->Name = self::$setNameWithoutVersionAfterPublish;
+            $this->writeWithoutVersion();
+        }
     }
 }


### PR DESCRIPTION
Created as part of looking into 
https://github.com/silverstripe/silverstripe-framework/issues/3557
but the test confirmed that no further changes are needed.

Notably, this test validates the creation of an extra Versions entry
on publication as designed behaviour, which appears to be the case.