### PR TITLE
FIX call to getQueryParam() on null error

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -468,11 +468,15 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
      * See {@see augmentLazyLoadFields} for lazy-loading applied prior to this.
      *
      * @param SQLSelect $query
-     * @param DataQuery $dataQuery
+     * @param DataQuery|null $dataQuery
      * @throws InvalidArgumentException
      */
     public function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null)
     {
+        if (!$dataQuery) {
+            return;
+        }
+
         // Ensure query mode exists
         $versionedMode = $dataQuery->getQueryParam('Versioned.mode');
         if (!$versionedMode) {


### PR DESCRIPTION
```
ERROR [Emergency]: Uncaught Error: Call to a member function getQueryParam() on null
```

Found the error during upgrade to SS4 on Step 11 migrating files with `dev/tasks/MigrateFileTask`. 
Installed packages include:
`silverstripe/framework: 4.4.x-dev`
`silverstripe/versioned: 1.4.x-dev`
`silverstripe/fulltextsearch: 3.4.2`

The error was triggered by the fulltextsearch module, `SearchIndex` on line 632 `singleton($step['class'])->extend('augmentSQL', $sql);`

I am aware that there's a [PR](https://github.com/silverstripe/silverstripe-fulltextsearch/pull/239) to fix this in fulltextsearch but the signature of the method causes it to fail by default which is IMO not a good practice. If `$dataQuery` is nullable due to legacy reasons, still we can't assume that this is always set therefore, a check is necessary before calling `$dataQuery->getQueryParam('Versioned.mode')`