### PR TITLE
FIX Revert framework constraint bump and add easly returns when non B/C interface does not exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.2",
+        "silverstripe/framework": "^4",
         "silverstripe/vendor-plugin": "^1"
     },
     "require-dev": {

--- a/src/GridFieldArchiveAction.php
+++ b/src/GridFieldArchiveAction.php
@@ -12,6 +12,10 @@ use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
 
+if (!interface_exists(GridField_ActionMenuItem::class)) {
+    return;
+}
+
 /**
  * This class is a {@link GridField} component that replaces the delete action
  * and adds an archive action for objects.

--- a/src/GridFieldRestoreAction.php
+++ b/src/GridFieldRestoreAction.php
@@ -13,6 +13,10 @@ use SilverStripe\ORM\ValidationException;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Versioned\RestoreAction;
 
+if (!interface_exists(GridField_ActionMenuItem::class)) {
+    return;
+}
+
 /**
  * This class is a {@link GridField} component that adds a restore action for
  * versioned objects.


### PR DESCRIPTION
This change must be released as a 1.3.x patch tag, then the Composer constraint can be bumped back again to where it was. This will fix cases where Composer installs silverstripe/versioned ~1.3.0 on older SilverStripe 4.0/4.1 projects, which has a backwards compatibility break in it.

The change here allows the code to be backwards compatible with older versions. Once tagged it can be bumped and re-tagged in future in the same release line without concerns for the same B/C break.

Issue: https://github.com/silverstripe/silverstripe-versioned/issues/230

Note that we've already decided it's OK to stop releasing core modules in lock step with each other - see https://github.com/silverstripe/silverstripe-framework/issues/8970