### PR TITLE
Revert "FIX Revert framework constraint bump and add easly returns when non B/C interface does not exist"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4",
+        "silverstripe/framework": "^4.2",
         "silverstripe/vendor-plugin": "^1"
     },
     "require-dev": {

--- a/src/GridFieldArchiveAction.php
+++ b/src/GridFieldArchiveAction.php
@@ -12,10 +12,6 @@ use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
 
-if (!interface_exists(GridField_ActionMenuItem::class)) {
-    return;
-}
-
 /**
  * This class is a {@link GridField} component that replaces the delete action
  * and adds an archive action for objects.

--- a/src/GridFieldRestoreAction.php
+++ b/src/GridFieldRestoreAction.php
@@ -13,10 +13,6 @@ use SilverStripe\ORM\ValidationException;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Versioned\RestoreAction;
 
-if (!interface_exists(GridField_ActionMenuItem::class)) {
-    return;
-}
-
 /**
  * This class is a {@link GridField} component that adds a restore action for
  * versioned objects.


### PR DESCRIPTION
This reverts commit 5df7f4f2708efe98daa6c2be8f0d5a2de6b0742d.

The previous commit has been released in 1.3.4, so we can restore the previous state from now on.

Issue: https://github.com/silverstripe/silverstripe-versioned/issues/230