### PR TITLE
FIX lookupReverseOwners to work in deriving classes

### DIFF
--- a/src/RecursivePublishable.php
+++ b/src/RecursivePublishable.php
@@ -244,7 +244,7 @@ class RecursivePublishable extends DataExtension
         array_shift($classes); // skip DataObject
         foreach ($classes as $class) {
             // Ensure this class is RecursivePublishable
-            if (!DataObject::has_extension($class, static::class)) {
+            if (!DataObject::has_extension($class, self::class)) {
                 continue;
             }
 


### PR DESCRIPTION
The fix allows classes extending RecursivePublishable to use `lookupReverseOwners`.
Currently, those aren't always explicitly registered as extensions and as such `DataObject::has_extension` may return false even if RecursivePublishable is there, but the particular calling extension is not.
`DataObject::has_extension` checks for deriving classes internally (unless a third parameter given).

# Related Issues

https://github.com/silverstripe/silverstripe-versioned/issues/72