### PR TITLE
Default Was Draft to true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ env:
   global:
     - COMPOSER_ROOT_VERSION=1.3.x-dev
 
+dist: trusty
+
 matrix:
   fast_finish: true
   include:

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -163,7 +163,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
         "Version" => "Int",
         "WasPublished" => "Boolean",
         "WasDeleted" => "Boolean",
-        "WasDraft" => "Boolean",
+        "WasDraft" => "Boolean(1)",
         "AuthorID" => "Int",
         "PublisherID" => "Int"
     ];


### PR DESCRIPTION
`WasDraft` didn't exist in SilverStripe 3. In most cases it will be set to `true`. Exception are when archiving a record or when publishing directly to live.

History view breaks in most cases when looking at records from SS3, because WasDraft default to false.

By default it to true we provided a better representation of the SilverStripe 3 data and we fix the history view.

Note that this will only fix new migration, not old one.

# Parent issue
* https://github.com/silverstripe/silverstripe-versioned-admin/issues/100