### PR TITLE
Allow actions to be taken after versioned has recorded a delete

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -1275,6 +1275,8 @@ SQL
         unset($manipulation[$baseTable]);
         $this->owner->extend('augmentWriteDeletedVersion', $manipulation, $stages);
         DB::manipulate($manipulation);
+        $this->owner->Version = $manipulation["{$baseTable}_Versions"]['fields']['Version'];
+        $this->owner->extend('onAfterVersionDelete');
     }
 
     public function augmentWrite(&$manipulation)


### PR DESCRIPTION
There are instances where you want to do actions after versioned has written the delete version.

An example of this is wanting to take a snapshot of a dataobject after it's been deleted. You'd currently get the wrong/correct version number depending on when the extension runs