### PR TITLE
Dupe: Allow actions to be taken after versioned has recorded a delete

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -1275,6 +1275,8 @@ SQL
         unset($manipulation[$baseTable]);
         $this->owner->extend('augmentWriteDeletedVersion', $manipulation, $stages);
         DB::manipulate($manipulation);
+        $this->owner->Version = $manipulation["{$baseTable}_Versions"]['fields']['Version'];
+        $this->owner->extend('onAfterVersionDelete');
     }
 
     public function augmentWrite(&$manipulation)


### PR DESCRIPTION
This is a dupe of https://github.com/silverstripe/silverstripe-versioned/pull/243
I just was hoping I could get this merged into 1.4 and tagged for a release of 1.4.x