### PR TITLE
FIX archive relationships, not related objects

### DIFF
--- a/src/GridFieldArchiveAction.php
+++ b/src/GridFieldArchiveAction.php
@@ -73,7 +73,16 @@ class GridFieldArchiveAction implements GridField_ColumnProvider, GridField_Acti
         $model = $gridField->getModelClass();
         $isModelVersioned = $model::has_extension(Versioned::class);
         if ($isModelVersioned) {
-            $gridField->getConfig()->removeComponentsByType(GridFieldDeleteAction::class);
+            $config = $gridField->getConfig();
+            $deleteComponents = $config->getComponentsByType(GridFieldDeleteAction::class);
+            foreach ($deleteComponents as $deleteComponent) {
+                if ($deleteComponent->getRemoveRelation()) {
+                    // The 'delete' button will "unlink" the relationship, NOT delete the item.
+                    continue;
+                }
+                // Deleting an item that is published would leave no way to unpublish it.
+                $config->removeComponent($deleteComponent);
+            }
         }
         if (!in_array('Actions', $columns)) {
             $columns[] = 'Actions';


### PR DESCRIPTION
The archive action is set to take the place of the delete button,
considering that when a published item is deleted (i.e. from the
draft table) then it cannot be unpublished as no interface exists
to do so.

However this was having the unintended affect of removing objects
people wished to only remove from a relationship list, as the
archive action did not account for whether the delete action intends
to remove the related object, or the link to it (the relationship).

This is most easily remedied by providing the user with both options.
It may not be the best user experience, but is the most flexible.

Resolves #200 