### PR TITLE
Added missing table versioning

### DIFF
--- a/_config/versionedextension.yml
+++ b/_config/versionedextension.yml
@@ -14,3 +14,9 @@ SilverStripe\Core\Injector\Injector:
       mode: StagedVersioned
   # Default is alias for .stagedversioned
   SilverStripe\Versioned\Versioned: '%$SilverStripe\Versioned\Versioned.stagedversioned'
+---
+Name: versioned-table
+---
+SilverStripe\ORM\DataQuery:
+  extensions:
+    - SilverStripe\Versioned\VersionedTableDataQueryExtension

--- a/src/VersionedTableDataQueryExtension.php
+++ b/src/VersionedTableDataQueryExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Versioned;
+
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\DataQuery;
+
+/**
+ * Applies correct stage to tables
+ *
+ * @property DataQuery $owner
+ */
+class VersionedTableDataQueryExtension extends Extension
+{
+    /**
+     * Extension point in @see DataQuery::getJoinTableName()
+     *
+     * @param string $class
+     * @param string $table
+     * @param string $updated
+     */
+    public function updateJoinTableName($class, $table, &$updated)
+    {
+        if (!Extensible::has_extension($class, Versioned::class)) {
+            return;
+        }
+
+        /** @var Versioned $versioned */
+        $versioned = Injector::inst()->get(Versioned::class);
+        $stage = $versioned->get_stage();
+        $updated = $versioned->stageTable($table, $stage);
+    }
+}

--- a/tests/php/VersionedTableTest/House.php
+++ b/tests/php/VersionedTableTest/House.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\VersionedTableTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\ManyManyThroughList;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class House
+ *
+ * @property string $Title
+ * @property int $RoofID
+ * @method WoodenRoof Roof()
+ * @method ManyManyThroughList|Visitor[] Visitors()
+ * @method HasManyList|HouseVisit[] HouseVisits()
+ * @package SilverStripe\Versioned\Tests\VersionedTableTest
+ */
+class House extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'VersionedTableTest_House';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar(50)',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_one = [
+        'Roof' => WoodenRoof::class,
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_many = [
+        'HouseVisits' => HouseVisit::class . '.House',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $many_many = [
+        'Visitors' => [
+            'through' => HouseVisit::class,
+            'from' => 'House',
+            'to' => 'Visitor',
+        ],
+    ];
+
+    /**
+     * @var array
+     */
+    private static $extensions = [
+        Versioned::class,
+    ];
+}

--- a/tests/php/VersionedTableTest/HouseVisit.php
+++ b/tests/php/VersionedTableTest/HouseVisit.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\VersionedTableTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class HouseVisit
+ *
+ * @property int $HouseID
+ * @property int $VisitorID
+ * @method House House()
+ * @method Visitor Visitor()
+ * @package SilverStripe\Versioned\Tests\VersionedTableTest
+ */
+class HouseVisit extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'VersionedTableTest_HouseVisit';
+
+    /**
+     * @var array
+     */
+    private static $has_one = [
+        'House' => House::class,
+        'Visitor' => Visitor::class,
+    ];
+
+    /**
+     * @var array
+     */
+    private static $extensions = [
+        Versioned::class,
+    ];
+}

--- a/tests/php/VersionedTableTest/Roof.php
+++ b/tests/php/VersionedTableTest/Roof.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\VersionedTableTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class Roof
+ *
+ * @property string $Title
+ * @package SilverStripe\Versioned\Tests\VersionedTableTest
+ */
+class Roof extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'VersionedTableTest_Roof';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar(50)',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $extensions = [
+        Versioned::class,
+    ];
+}

--- a/tests/php/VersionedTableTest/VersionedTableTest.php
+++ b/tests/php/VersionedTableTest/VersionedTableTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\VersionedTableTest;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Versioned\Versioned;
+
+class VersionedTableTest extends SapphireTest
+{
+    /**
+     * @var string
+     */
+    protected static $fixture_file = 'VersionedTableTest.yml';
+
+    /**
+     * @var array
+     */
+    protected static $extra_dataobjects = [
+        House::class,
+        HouseVisit::class,
+        Visitor::class,
+        Roof::class,
+        WoodenRoof::class,
+    ];
+
+    /**
+     * @var array
+     */
+    protected static $required_extensions = [
+        House::class => [
+            Versioned::class,
+        ],
+        HouseVisit::class => [
+            Versioned::class,
+        ],
+        Visitor::class => [
+            Versioned::class,
+        ],
+        Roof::class => [
+            Versioned::class,
+        ],
+    ];
+
+    public function testApplyRelationHasOneVersioned()
+    {
+        Versioned::withVersionedMode(function () {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            /** @var House|Versioned $house1 */
+            $house1 = $this->objFromFixture(House::class, 'house-1');
+
+            /** @var WoodenRoof|Versioned $roof1 */
+            $roof1 = $this->objFromFixture(WoodenRoof::class, 'roof-1');
+
+            $house1->publishRecursive();
+
+            Versioned::withVersionedMode(function () {
+                Versioned::set_stage(Versioned::LIVE);
+
+                // check has one
+                $columnName = null;
+                $roofs = House::get()
+                    ->applyRelation('Roof.ID', $columnName)
+                    ->where(sprintf('%s IS NOT NULL', $columnName))
+                    ->columnUnique($columnName);
+
+                $this->assertEquals(0, count($roofs));
+            });
+
+            $roof1->publishRecursive();
+
+            Versioned::withVersionedMode(function () {
+                Versioned::set_stage(Versioned::LIVE);
+
+                // check has one
+                $columnName = null;
+                $roofs = House::get()
+                    ->applyRelation('Roof.ID', $columnName)
+                    ->where(sprintf('%s IS NOT NULL', $columnName))
+                    ->columnUnique($columnName);
+
+                $this->assertEquals(1, count($roofs));
+            });
+        });
+    }
+
+    public function testApplyRelationHasManyAndManyManyVersioned()
+    {
+        Versioned::withVersionedMode(function () {
+            Versioned::set_stage(Versioned::DRAFT);
+
+            /** @var House|Versioned $house1 */
+            $house1 = $this->objFromFixture(House::class, 'house-1');
+
+            /** @var HouseVisit|Versioned $houseVisit1 */
+            $houseVisit1 = $this->objFromFixture(HouseVisit::class, 'visit-1');
+
+            /** @var Visitor|Versioned $visitor1 */
+            $visitor1 = $this->objFromFixture(Visitor::class, 'visitor-1');
+
+            $house1->publishRecursive();
+
+            Versioned::withVersionedMode(function () {
+                Versioned::set_stage(Versioned::LIVE);
+
+                // check has many
+                $columnName = null;
+                $visitors = House::get()
+                    ->applyRelation('HouseVisits.VisitorID', $columnName)
+                    ->where(sprintf('%s IS NOT NULL', $columnName))
+                    ->columnUnique($columnName);
+
+                $this->assertEquals(0, count($visitors));
+
+                // check many many
+                $columnName = null;
+                $visitors = House::get()
+                    ->applyRelation('Visitors.ID', $columnName)
+                    ->where(sprintf('%s IS NOT NULL', $columnName))
+                    ->columnUnique($columnName);
+
+                $this->assertEquals(0, count($visitors));
+            });
+
+            $houseVisit1->publishRecursive();
+
+            Versioned::withVersionedMode(function () {
+                Versioned::set_stage(Versioned::LIVE);
+
+                // check has many
+                $columnName = null;
+                $visitors = House::get()
+                    ->applyRelation('HouseVisits.VisitorID', $columnName)
+                    ->where(sprintf('%s IS NOT NULL', $columnName))
+                    ->columnUnique($columnName);
+
+                $this->assertEquals(1, count($visitors));
+
+                // check many many
+                $columnName = null;
+                $visitors = House::get()
+                    ->applyRelation('Visitors.ID', $columnName)
+                    ->where(sprintf('%s IS NOT NULL', $columnName))
+                    ->columnUnique($columnName);
+
+                $this->assertEquals(0, count($visitors));
+            });
+
+            $visitor1->publishRecursive();
+
+            Versioned::withVersionedMode(function () {
+                Versioned::set_stage(Versioned::LIVE);
+
+                // check has many
+                $columnName = null;
+                $visitors = House::get()
+                    ->applyRelation('HouseVisits.VisitorID', $columnName)
+                    ->where(sprintf('%s IS NOT NULL', $columnName))
+                    ->columnUnique($columnName);
+
+                $this->assertEquals(1, count($visitors));
+
+                // check many many
+                $columnName = null;
+                $visitors = House::get()
+                    ->applyRelation('Visitors.ID', $columnName)
+                    ->where(sprintf('%s IS NOT NULL', $columnName))
+                    ->columnUnique($columnName);
+
+                $this->assertEquals(1, count($visitors));
+            });
+        });
+    }
+}

--- a/tests/php/VersionedTableTest/VersionedTableTest.yml
+++ b/tests/php/VersionedTableTest/VersionedTableTest.yml
@@ -1,0 +1,17 @@
+SilverStripe\Versioned\Tests\VersionedTableTest\WoodenRoof:
+  roof-1:
+    Title: 'Roof1'
+
+SilverStripe\Versioned\Tests\VersionedTableTest\House:
+  house-1:
+    Title: 'House1'
+    Roof: =>SilverStripe\Versioned\Tests\VersionedTableTest\WoodenRoof.roof-1
+
+SilverStripe\Versioned\Tests\VersionedTableTest\Visitor:
+  visitor-1:
+    Title: 'Visitor1'
+
+SilverStripe\Versioned\Tests\VersionedTableTest\HouseVisit:
+  visit-1:
+    House: =>SilverStripe\Versioned\Tests\VersionedTableTest\House.house-1
+    Visitor: =>SilverStripe\Versioned\Tests\VersionedTableTest\Visitor.visitor-1

--- a/tests/php/VersionedTableTest/Visitor.php
+++ b/tests/php/VersionedTableTest/Visitor.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\VersionedTableTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\ManyManyThroughList;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class Visitor
+ *
+ * @property string $Title
+ * @method ManyManyThroughList|House[] Houses()
+ * @method HasManyList|HouseVisit[] VisitedHouses()
+ * @package SilverStripe\Versioned\Tests\VersionedTableTest
+ */
+class Visitor extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'VersionedTableTest_Visitor';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar(50)',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_many = [
+        'VisitedHouses' => HouseVisit::class.'.Visitor',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $belongs_many_many = [
+        'Houses' => House::class.'.Visitors',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $extensions = [
+        Versioned::class,
+    ];
+}

--- a/tests/php/VersionedTableTest/WoodenRoof.php
+++ b/tests/php/VersionedTableTest/WoodenRoof.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\VersionedTableTest;
+
+/**
+ * Class WoodenRoof
+ *
+ * @property int $WoodType
+ * @method House House()
+ * @package SilverStripe\Versioned\Tests\VersionedTableTest
+ */
+class WoodenRoof extends Roof
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'VersionedTableTest_WoodenRoof';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'WoodType' => 'Int',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $belongs_to = [
+        'House' => House::class.'.WoodenRoof',
+    ];
+}


### PR DESCRIPTION
## Versioned table fix

* `DataQuery::applyRelation` now supports versioned tables
* `ManyManyThroughList` no longer leaks draft content

## Related issues

https://github.com/silverstripe/silverstripe-versioned/issues/254

## Dependencies

https://github.com/silverstripe/silverstripe-framework/pull/9386

## Notes

Split from https://github.com/silverstripe/silverstripe-framework/pull/8856