### PR TITLE
Versioned now supports injection

### DIFF
--- a/src/State/ReadingMode.php
+++ b/src/State/ReadingMode.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SilverStripe\Versioned\State;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Versioned\ReadingMode as ReadingModeValidator;
+use SilverStripe\Versioned\Versioned;
+
+class ReadingMode
+{
+
+    use Injectable;
+
+    /**
+     * The default reading mode is live
+     */
+    const DEFAULT = 'Stage.' . Versioned::LIVE;
+
+    /**
+     * Current reading mode. Supports stage / archive modes.
+     *
+     * @var string
+     */
+    protected $readingMode = null;
+
+    /**
+     * Default reading mode, if none set.
+     * Any modes which differ to this value should be assigned via querystring / session (if enabled)
+     *
+     * @var string|null
+     */
+    protected $defaultReadingMode = ReadingMode::DEFAULT;
+
+    /**
+     * @param string|null $readingMode
+     * @param bool $prependStage - Prepend 'Stage.', set to true by default
+     */
+    public function set(?string $readingMode, bool $prependStage = true): void
+    {
+        $this->readingMode = $prependStage
+            ? 'Stage.' . $readingMode
+            : $readingMode;
+    }
+
+    public function setWithArchiveDate(string $date, string $stage = Versioned::DRAFT): void
+    {
+        ReadingModeValidator::validateStage($stage);
+        $this->set('Archive.' . $date . '.' . $stage, false);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function get(): ?string
+    {
+        return $this->readingMode;
+    }
+
+    /**
+     * @param string|null $readingMode
+     */
+    public function setDefault(?string $readingMode): void
+    {
+        $this->defaultReadingMode = $readingMode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDefault(): ?string
+    {
+        return $this->defaultReadingMode ?: static::DEFAULT;
+    }
+
+    /**
+     * Reset the reading mode
+     */
+    public function reset(): void
+    {
+        $this->set('');
+        Controller::curr()->getRequest()->getSession()->clear('readingMode');
+    }
+}

--- a/src/State/ReadingMode.php
+++ b/src/State/ReadingMode.php
@@ -38,7 +38,7 @@ class ReadingMode
      */
     public function set(?string $readingMode, bool $prependStage = true): void
     {
-        $this->readingMode = $prependStage
+        $this->readingMode = $prependStage && $readingMode !== null && $readingMode !== ''
             ? 'Stage.' . $readingMode
             : $readingMode;
     }

--- a/src/State/ReadingMode.php
+++ b/src/State/ReadingMode.php
@@ -34,13 +34,10 @@ class ReadingMode
 
     /**
      * @param string|null $readingMode
-     * @param bool $prependStage - Prepend 'Stage.', set to true by default
      */
-    public function set(?string $readingMode, bool $prependStage = true): void
+    public function set(?string $readingMode): void
     {
-        $this->readingMode = $prependStage && $readingMode !== null && $readingMode !== ''
-            ? 'Stage.' . $readingMode
-            : $readingMode;
+        $this->readingMode = $readingMode;
     }
 
     public function setWithArchiveDate(string $date, string $stage = Versioned::DRAFT): void

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2464,6 +2464,11 @@ SQL
      */
     public static function set_draft_site_secured($secured)
     {
+        // If secured is null then we will treat it as secure
+        $secured = $secured === null
+            ? true
+            : $secured;
+
         Versioned::singleton()->setDraftSiteSecured((bool) $secured);
     }
 

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -3072,7 +3072,7 @@ SQL
      *
      * @return DataObject
      */
-    public function getVersion(string $class, int $id, int $version): ?DataObject
+    public function getVersionOf(string $class, int $id, int $version): ?DataObject
     {
         $baseClass = DataObject::getSchema()->baseDataClass($class);
         $list = DataList::create($baseClass)
@@ -3100,7 +3100,7 @@ SQL
      */
     public static function get_version($class, $id, $version)
     {
-        Versioned::singleton()->getVersion($class, (int) $id, (int) $version);
+        Versioned::singleton()->getVersionOf($class, (int) $id, (int) $version);
     }
 
     /**

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -356,7 +356,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider, Resetta
 
         // By version number
         if (is_numeric($from)) {
-            return Versioned::singleton()->getVersion($baseClass, $id, $from);
+            return Versioned::singleton()->getVersionOf($baseClass, $id, $from);
         }
 
         // By stage
@@ -2138,8 +2138,8 @@ SQL
     public function compareVersions($from, $to)
     {
         $owner = $this->owner;
-        $fromRecord = Versioned::singleton()->getVersion(get_class($owner), $owner->ID, $from);
-        $toRecord = Versioned::singleton()->getVersion(get_class($owner), $owner->ID, $to);
+        $fromRecord = Versioned::singleton()->getVersionOf(get_class($owner), $owner->ID, $from);
+        $toRecord = Versioned::singleton()->getVersionOf(get_class($owner), $owner->ID, $to);
 
         $diff = new DataDifferencer($fromRecord, $toRecord);
 
@@ -2276,7 +2276,7 @@ SQL
      */
     public static function set_reading_mode($readingMode)
     {
-        ReadingModeState::singleton()->set($readingMode, false);
+        ReadingModeState::singleton()->set($readingMode);
     }
 
     /**
@@ -2380,7 +2380,7 @@ SQL
     public function setStage(?string $stage): void
     {
         ReadingMode::validateStage($stage);
-        ReadingModeState::singleton()->set($stage);
+        ReadingModeState::singleton()->set('Stage.' . $stage);
     }
 
     /**
@@ -2577,7 +2577,7 @@ SQL
      */
     public static function get_versionnumber_by_stage($class, $stage, $id, $cache = true)
     {
-        return Versioned::singleton()->getVersionNumberByStage($class, $stage, $id, $cache);
+        return Versioned::singleton()->getVersionNumberByStage($class, (string) $stage, (int) $id, (bool) $cache);
     }
 
     /**
@@ -3096,11 +3096,11 @@ SQL
      * @param int $version
      *
      * @return DataObject
-     * @deprecated 4..5 use Versioned::singleton()->getVersion($class, $id, $version);
+     * @deprecated 4..5 use Versioned::singleton()->getVersionOf($class, $id, $version);
      */
     public static function get_version($class, $id, $version)
     {
-        Versioned::singleton()->getVersionOf($class, (int) $id, (int) $version);
+        return Versioned::singleton()->getVersionOf($class, (int) $id, (int) $version);
     }
 
     /**

--- a/tests/php/Injection/VersionedInjected.php
+++ b/tests/php/Injection/VersionedInjected.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests;
+
+use SilverStripe\Versioned\Versioned;
+
+class VersionedInjected extends Versioned
+{
+    public function getIncludingDeleted($class, $filter = "", $sort = "")
+    {
+        return 'hello';
+    }
+}

--- a/tests/php/Injection/VersionedInjectionTest.php
+++ b/tests/php/Injection/VersionedInjectionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+class VersionedInjectionTest extends SapphireTest
+{
+    protected static $required_extensions = [
+        DataObject::class => [
+            Versioned::class,
+        ],
+    ];
+
+    public function testInjectionWorks(): void
+    {
+        Injector::inst()->registerService(VersionedInjected::create(), Versioned::class);
+        $this->assertEquals('hello', Versioned::singleton()->getIncludingDeleted('', '', ''));
+        $this->assertEquals('hello', DataObject::create()->getIncludingDeleted('', '' ,''));
+    }
+}


### PR DESCRIPTION
Completed as part of: https://github.com/silverstripe/silverstripe-versioned/issues/252

For this I've moved the reading state out into it's own class that can be handled separately and then deprecated all the static functions by replacing them with ones you can call on the instance.

I think this is probably a good first step. Ideally in another version we'll seperate the code out which I would have liked to do here but would have increased the size of the PR to be too big