### PR TITLE
BUG: Write to stage extension point params.

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2619,11 +2619,11 @@ SQL
                 $owner->setSourceQueryParam('Versioned.stage', $stage);
 
                 // Write
-                $owner->invokeWithExtensions('onBeforeWriteToStage', $toStage, $forceInsert);
+                $owner->invokeWithExtensions('onBeforeWriteToStage', $stage, $forceInsert);
                 return $owner->write(false, $forceInsert);
             } finally {
                 // Revert global state
-                $owner->invokeWithExtensions('onAfterWriteToStage', $toStage, $forceInsert);
+                $owner->invokeWithExtensions('onAfterWriteToStage', $stage, $forceInsert);
                 $owner->setSourceQueryParams($oldParams);
             }
         });


### PR DESCRIPTION
# Write to stage extension point params.

* extension point uses undefined variable
* this doesn't throw only because it's passed as a reference
* in current situation this is effectively the same as always passing `null`

## Short term workaround

* following line of code can be used as a short term workaround until this fix comes through
* put following line into your extension code to determine the stage

```
$stage = Versioned::get_stage()
```

## Related issues

https://github.com/silverstripe/silverstripe-versioned/issues/277