### PR TITLE
Show the type of save that was performed for the record instead of just showing either Saved/Published.

### DIFF
--- a/src/GraphQL/Extensions/DataObjectScaffolderExtension.php
+++ b/src/GraphQL/Extensions/DataObjectScaffolderExtension.php
@@ -58,6 +58,18 @@ class DataObjectScaffolderExtension extends Extension
                             return $obj->WasPublished;
                         }
                     ],
+                    'Draft' => [
+                        'type' => Type::boolean(),
+                        'resolve' => function ($obj) {
+                            return $obj->WasDraft;
+                        }
+                    ],
+                    'Deleted' => [
+                        'type' => Type::boolean(),
+                        'resolve' => function ($obj) {
+                            return $obj->WasDeleted;
+                        }
+                    ],
                     'LiveVersion' => [
                         'type' => Type::boolean(),
                         'resolve' => function ($obj) {

--- a/src/GraphQL/Resolvers/ApplyVersionFilters.php
+++ b/src/GraphQL/Resolvers/ApplyVersionFilters.php
@@ -30,6 +30,7 @@ class ApplyVersionFilters
             case Versioned::LIVE:
             case Versioned::DRAFT:
             case 'latest_versions':
+            case 'all_versions':
                 Versioned::set_stage($mode);
                 break;
             case 'archive':
@@ -77,6 +78,9 @@ class ApplyVersionFilters
                 $list = $list
                     ->setDataQueryParam('Versioned.mode', 'archive')
                     ->setDataQueryParam('Versioned.date', $date);
+                break;
+            case 'all_versions':
+                $list = $list->setDataQueryParam('Versioned.mode', 'all_versions');
                 break;
             case 'latest_versions':
                 $list = $list->setDataQueryParam('Versioned.mode', 'latest_versions');
@@ -182,6 +186,8 @@ class ApplyVersionFilters
                         $date
                     ));
                 }
+                break;
+            case 'all_versions':
                 break;
             case 'latest_versions':
                 break;

--- a/src/GraphQL/Types/VersionedQueryMode.php
+++ b/src/GraphQL/Types/VersionedQueryMode.php
@@ -38,6 +38,10 @@ class VersionedQueryMode extends TypeCreator
                 'value' => 'latest_versions',
                 'description' => 'Read the latest version',
             ],
+            'ALL_VERSIONS' => [
+                'value' => 'all_versions',
+                'description' => 'Reads all versions',
+            ],
             'DRAFT' => [
                 'value' => Versioned::DRAFT,
                 'description' => 'Read from the draft stage',

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -1156,7 +1156,7 @@ SQL
         ];
 
         // Add any extra, unchanged fields to the version record.
-            $data = DB::prepared_query("SELECT * FROM \"{$table}\" WHERE \"ID\" = ?", [$recordID])->record();
+        $data = DB::prepared_query("SELECT * FROM \"{$table}\" WHERE \"ID\" = ?", [$recordID])->record();
         if ($data) {
             $fields = $schema->databaseFields($class, false);
             if (is_array($fields)) {

--- a/tests/php/GraphQL/Resolvers/ApplyVersionFiltersTest.php
+++ b/tests/php/GraphQL/Resolvers/ApplyVersionFiltersTest.php
@@ -161,6 +161,20 @@ class ApplyVersionFiltersTest extends SapphireTest
         $this->assertEquals('latest_versions', $list->dataQuery()->getQueryParam('Versioned.mode'));
     }
 
+    public function testItSetsAllVersionsQueryParamsOnApplyToList()
+    {
+        $filter = new ApplyVersionFilters();
+        $list = Fake::get();
+        $filter->applyToList(
+            $list,
+            [
+                'Mode' => 'all_versions',
+            ]
+        );
+
+        $this->assertEquals('all_versions', $list->dataQuery()->getQueryParam('Versioned.mode'));
+    }
+
     public function testItThrowsOnNoStatusOnApplyToList()
     {
         $filter = new ApplyVersionFilters();

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -20,6 +20,7 @@ use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\IdentityStore;
 use SilverStripe\Versioned\ChangeSet;
+use SilverStripe\Versioned\Tests\VersionedTest\TestObject;
 use SilverStripe\Versioned\Versioned;
 
 class VersionedTest extends SapphireTest
@@ -1587,6 +1588,27 @@ class VersionedTest extends SapphireTest
             ],
             $versions
         );
+    }
+
+    public function testArchivedEntries()
+    {
+        // create a new record and save it
+        $record = new VersionedTest\TestObject();
+        $record->Title = 'My record';
+        $record->write();
+
+        // then archive it
+        $record->doArchive();
+
+        // ensure we can retrieve the archived entry when retrieving versioned entries
+        $versions = $record->VersionsList()->toArray();
+        $this->assertCount(2, $versions, 'All versions are retrieved');
+        /** @var TestObject $archivedVersion */
+        $archivedVersion = $versions[1];
+        $this->assertEquals(true, $archivedVersion->isArchived(), 'Archived entry is included in version list');
+
+        // ensure our fields are preserved for the archived version entry
+        $this->assertEquals('My record', $archivedVersion->Title, 'Archived entry fields are populated');
     }
 
     public function testLiveObjectDeletedOnUnpublish()

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -1596,18 +1596,30 @@ class VersionedTest extends SapphireTest
         $record->Title = 'My record';
         $record->write();
 
+        // publish it
+        $record->publishSingle();
+
         // then archive it
         $record->doArchive();
 
-        // ensure we can retrieve the archived entry when retrieving versioned entries
+        // ensure the version entries are correct
         $versions = $record->VersionsList()->toArray();
-        $this->assertCount(2, $versions, 'All versions are retrieved');
-        /** @var TestObject $archivedVersion */
-        $archivedVersion = $versions[1];
-        $this->assertEquals(true, $archivedVersion->isArchived(), 'Archived entry is included in version list');
+        $this->assertCount(3, $versions, 'All versions should be retrieved');
 
-        // ensure our fields are preserved for the archived version entry
-        $this->assertEquals('My record', $archivedVersion->Title, 'Archived entry fields are populated');
+        /** @var TestObject $createdVersion */
+        $createdVersion = $versions[0];
+        $this->assertEquals(1, $createdVersion->WasDraft, 'Created version should be draft');
+        $this->assertEquals(0, $createdVersion->WasPublished, 'Created version should not be published');
+        $this->assertEquals(0, $createdVersion->WasDeleted, 'Created version should not be deleted');
+
+        /** @var TestObject $publishedVersion */
+        $publishedVersion = $versions[1];
+        $this->assertEquals(1, $publishedVersion->WasPublished, 'Published version should be published');
+
+        /** @var TestObject $archivedVersion */
+        $archivedVersion = $versions[2];
+        $this->assertEquals(true, $archivedVersion->isArchived(), 'Archived entry should be included in version list');
+        $this->assertEquals('My record', $archivedVersion->Title, 'Archived entry fields should be preserved');
     }
 
     public function testLiveObjectDeletedOnUnpublish()

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -20,7 +20,6 @@ use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\IdentityStore;
 use SilverStripe\Versioned\ChangeSet;
-use SilverStripe\Versioned\Tests\VersionedTest\TestObject;
 use SilverStripe\Versioned\Versioned;
 
 class VersionedTest extends SapphireTest


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-cms/issues/2448

* Save fields to archived version entries (previously these entries would save without any fields on them)
* Show archived/deleted version entries instead of filtering them out