### PR TITLE
FIX: Fix semantics of isPublished(), isArchived(), isOnDraft() for objects without draft/published stages

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2810,6 +2810,7 @@ SQL
 
     /**
      * Check if this record exists on live
+     * On objects with only 1 stage, check if the record exists on that stage.
      *
      * @return bool
      */
@@ -2822,7 +2823,7 @@ SQL
 
         // Non-staged objects are considered "published" if saved
         if (!$this->hasStages()) {
-            return true;
+            return $this->isOnDraft();
         }
 
         $liveVersion = static::get_versionnumber_by_stage($this->owner, Versioned::LIVE, $id);
@@ -2846,7 +2847,8 @@ SQL
     }
 
     /**
-     * Check if this record exists on the draft stage
+     * Check if this record exists on the draft stage.
+     * On objects with only 1 stage, check if the record exists on that stage.
      *
      * @return bool
      */
@@ -2855,9 +2857,6 @@ SQL
         $id = $this->owner->ID ?: $this->owner->OldID;
         if (!$id) {
             return false;
-        }
-        if (!$this->hasStages()) {
-            return true;
         }
 
         $draftVersion = static::get_versionnumber_by_stage($this->owner, Versioned::DRAFT, $id);

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -954,6 +954,27 @@ class VersionedTest extends SapphireTest
         );
     }
 
+    public function testSingleStageDraftPublished()
+    {
+
+        $obj = new VersionedTest\SingleStage(['Name' => 'MyObj']);
+        $this->assertFalse($obj->isOnDraft());
+        $this->assertFalse($obj->isPublished());
+
+        $obj->write();
+        $this->assertTrue($obj->isOnDraft());
+        $this->assertTrue($obj->isPublished());
+
+        $id = $obj->ID;
+        $obj->delete();
+        $this->assertFalse($obj->isOnDraft());
+        $this->assertFalse($obj->isPublished());
+
+        $recoveredObj = Versioned::get_latest_version(VersionedTest\SingleStage::class, $id);
+        $this->assertFalse($recoveredObj->isOnDraft());
+        $this->assertFalse($recoveredObj->isPublished());
+    }
+
     /**
      * Test that publishing processes respects lazy loaded fields
      */


### PR DESCRIPTION
The existing code did nothing useful - returning true all the time for
these cases. This patch fixes them be a more meaningful semantic, where
draft and published are treated as being the same stage.

isOnLiveOnly() will never be true in such cases, and isPublished() will
always be the same as isOnDraft().

To do:

* [x] add tests for single-stage case