### PR TITLE
FIX Re-fetch DataObject when unpublishing to handle modified state

### DIFF
--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -1588,4 +1588,21 @@ class VersionedTest extends SapphireTest
             $versions
         );
     }
+
+    public function testLiveObjectDeletedOnUnpublish()
+    {
+        /** @var VersionedTest\TestObject|Versioned $obj */
+        $obj = new VersionedTest\TestObject();
+
+        // publish
+        $obj->Name = 'First name';
+        $obj->publishSingle();
+
+        // put into a modified state
+        $obj->Name = 'Second name';
+        $obj->write();
+
+        $obj->doUnpublish();
+        $this->assertEquals('First name', VersionedTest\TestObject::$nameValueOfObjectJustDeleted);
+    }
 }

--- a/tests/php/VersionedTest/TestObject.php
+++ b/tests/php/VersionedTest/TestObject.php
@@ -58,6 +58,11 @@ class TestObject extends DataObject implements TestOnly
      */
     public static $setNameWithoutVersionAfterPublish = null;
 
+    /**
+     * Used to record the $obj->Name value of the last object deleted
+     */
+    public static $nameValueOfObjectJustDeleted = '';
+
     public function canView($member = null)
     {
         $extended = $this->extendedCan(__FUNCTION__, $member);
@@ -73,5 +78,11 @@ class TestObject extends DataObject implements TestOnly
             $this->Name = self::$setNameWithoutVersionAfterPublish;
             $this->writeWithoutVersion();
         }
+    }
+
+    public function onAfterDelete()
+    {
+        parent::onAfterDelete();
+        self::$nameValueOfObjectJustDeleted = $this->Name;
     }
 }


### PR DESCRIPTION
Fix for https://github.com/silverstripe/silverstripe-assets/issues/371

Co-authored-by: Maxime Rainville <maxime@silverstripe.com>