### PR TITLE
FIX: Decouple test setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 /**/*.js.map
+vendor/
+resources/
+composer.lock
+assets/

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
-        "silverstripe/admin": "^1",
-        "squizlabs/php_codesniffer": "^3"
+        "squizlabs/php_codesniffer": "^3",
+        "silverstripe/graphql": "^3"
     },
     "extra": {
         "expose": [

--- a/tests/php/VersionedStateExtensionTest.php
+++ b/tests/php/VersionedStateExtensionTest.php
@@ -65,6 +65,11 @@ class VersionedStateExtensionTest extends SapphireTest
 
     public function testDontUpdateLeftAndMainLinks()
     {
+        if (!class_exists(LeftAndMain::class)) {
+            $this->markTestSkipped('silverstripe/cms not installed');
+            return;
+        }
+
         $controller = new LeftAndMain();
 
         $liveClientConfig = $controller->getClientConfig();

--- a/tests/php/VersionedTest/TestObject.php
+++ b/tests/php/VersionedTest/TestObject.php
@@ -34,7 +34,7 @@ class TestObject extends DataObject implements TestOnly
     private static $db = [
         "Name" => "Varchar",
         'Title' => 'Varchar',
-        'Content' => 'HTMLText',
+        'Content' => 'Text',
     ];
 
     private static $extensions = [


### PR DESCRIPTION
Decoupling modules so that versioned doesn’t rely on an arbitrary and
undefined subset of the CMS recipe nudges our architecture in the right
direction. A more successful decomposition of the recipe into packages
would ensure that there aren’t bidirectional or cyclic relationships
between packages, and instead they are arranged more into “layers”.

This patch means that you can test the module independently, like so:

 * (clone module)
 * composer install
 * vendor/bin/phpunit

The test suit not longer relies on HTMLEditorField, which in practise
is not fully functional without admin. It also skips 

There is 1 test that appears to test a piece of LeftAndMain behaviour.
Arguably it should be refactored and placed there, but I’ve made it
skippable instead.

With that in place it tightens the require-dev dependencies to only
include graphql, as some of the test suite tests the graphql/versioned
behaviour.

I haven’t changed the travis.yml configuration as is appears these are
being auto-generated to be consistent across all modules that make up
the CMS recipe (44fb86acffcd3f4041b03f12299b07348439b2f0).