### PR TITLE
Improvement: Update Versioned Admin menu title to "Archive"

### DIFF
--- a/lang/de.yml
+++ b/lang/de.yml
@@ -1,10 +1,4 @@
 de:
-  SilverStripe\VersionedAdmin\ArchiveAdmin:
-    MENUTITLE: Archiv
-  SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController:
-    MENUTITLE: 'Seite bearbeiten'
-  SilverStripe\VersionedAdmin\Controllers\HistoryViewerController:
-    MENUTITLE: Versionsverlauf
   SilverStripe\Versioned\ChangeSet:
     EMPTY: Leer
     ITEMS_CHANGES:

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,6 +1,6 @@
 en:
   SilverStripe\VersionedAdmin\ArchiveAdmin:
-    MENUTITLE: Archives
+    MENUTITLE: Archive
   SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController:
     MENUTITLE: 'Edit Page'
   SilverStripe\VersionedAdmin\Controllers\HistoryViewerController:

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,10 +1,4 @@
 en:
-  SilverStripe\VersionedAdmin\ArchiveAdmin:
-    MENUTITLE: Archive
-  SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController:
-    MENUTITLE: 'Edit Page'
-  SilverStripe\VersionedAdmin\Controllers\HistoryViewerController:
-    MENUTITLE: SilverStripe\VersionedAdmin\Controllers\HistoryViewerController
   SilverStripe\Versioned\ChangeSet:
     EMPTY: Empty
     ITEMS_CHANGES:

--- a/lang/fi.yml
+++ b/lang/fi.yml
@@ -1,10 +1,4 @@
 fi:
-  SilverStripe\VersionedAdmin\ArchiveAdmin:
-    MENUTITLE: Arkistot
-  SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController:
-    MENUTITLE: 'Muokkaa sivua'
-  SilverStripe\VersionedAdmin\Controllers\HistoryViewerController:
-    MENUTITLE: SilverStripe\VersionedAdmin\Controllers\HistoryViewerController
   SilverStripe\Versioned\ChangeSet:
     EMPTY: Tyhjä
     ITEMS_CHANGES:

--- a/lang/pl.yml
+++ b/lang/pl.yml
@@ -1,8 +1,4 @@
 pl:
-  SilverStripe\VersionedAdmin\ArchiveAdmin:
-    MENUTITLE: Archiwum
-  SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController:
-    MENUTITLE: 'Edytuj stronę'
   SilverStripe\Versioned\ChangeSet:
     EMPTY: Pusty
     ITEMS_CHANGES:


### PR DESCRIPTION
Fixes: https://github.com/silverstripe/silverstripe-versioned-admin/issues/156

> This was a design mishap where it was updated in one place and not another causing inconsistent across the board when it was developed.