### PR TITLE
FIX Prevent ProxyCacheAdapter contents from being serialized

### DIFF
--- a/src/Caching/ProxyCacheAdapter.php
+++ b/src/Caching/ProxyCacheAdapter.php
@@ -37,6 +37,18 @@ abstract class ProxyCacheAdapter implements CacheInterface, ResettableInterface,
     }
 
     /**
+     * Do not serialize() `$this->pool` because it may contain a non-serializable cache.
+     * For instance, Symfony\Component\Cache\Simple\FilesystemCache cannot be serialized because in will throw an
+     * exception in Symfony\Component\Cache\Traits\FilesystemCommonTrait::__sleep()
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        return [];
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function get($key, $default = null)


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-versionfeed/issues/59

This prevents logging pollution from people using `/changes` and `/allchanges` from the versionfeed module, as well as possibly some other use cases.

This happens because those particular endpoints attempt to cache an `ArrayList` of `SiteTree` which have a property `protected $creatableChildrenCache` which at serialize time is a `VersionedCacheAdapter extends ProxyCacheAdapter` which has a pool of caches that will throw an exceptions when they are attempted to be `serialized()`.  Those caches will `serialize()` objects before writing them to disk/memory, so presumably those exceptions are there to prevent it from adding itself to its own cache.

To replicate the error, install kitchen-sink which includes frameworktest and go to `/about-us/allchanges`.  You may need to update the config value for `allchanges_enabled`

I've targeted a pretty old version (1.4) not because this is a super important website feature, but instead because users on old versions may do a patch update which will reduce the stress on platform logging noise and disk space.

I'm not sure if implementing the public magic method `public function __sleep()` constitutes new API or not. If it does then we should retarget this to `1` and release it with `1.7`