### PR TITLE
Fixed implicit GraphQL dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
   # Fix for running phpunit 5 on php 7.4+
   - composer require --no-update sminnee/phpunit-mock-objects:^3
 
-  - 'if [[ ! $BACKWARD_COMPAT ]]; then composer require silverstripe/graphql:4.x-dev --no-update; fi'
+  - 'if [[ $BACKWARD_COMPAT ]]; then composer require silverstripe/graphql:3.x-dev --no-update; fi'
 
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:^2 --no-update; fi
   - composer update --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile $COMPOSER_ARG

--- a/_legacy/GraphQL/Extensions/DataObjectScaffolderExtension.php
+++ b/_legacy/GraphQL/Extensions/DataObjectScaffolderExtension.php
@@ -12,6 +12,8 @@ use SilverStripe\Security\Member;
 use SilverStripe\Versioned\GraphQL\Operations\ReadVersions;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(Manager::class)) {
     return;
 }

--- a/_legacy/GraphQL/Extensions/DeleteExtension.php
+++ b/_legacy/GraphQL/Extensions/DeleteExtension.php
@@ -9,6 +9,12 @@ use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 /**
  * Extends the @see Delete CRUD scaffolder to unpublish any items first
  *

--- a/_legacy/GraphQL/Extensions/ManagerExtension.php
+++ b/_legacy/GraphQL/Extensions/ManagerExtension.php
@@ -10,6 +10,12 @@ use SilverStripe\Versioned\GraphQL\Types\VersionedStage;
 use SilverStripe\Versioned\GraphQL\Types\VersionedStatus;
 use SilverStripe\Versioned\GraphQL\Types\VersionSortType;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 /**
  * @deprecated 4.8..5.0 Use silverstripe/graphql:^4 functionality.
  */

--- a/_legacy/GraphQL/Extensions/ReadExtension.php
+++ b/_legacy/GraphQL/Extensions/ReadExtension.php
@@ -11,6 +11,12 @@ use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\ORM\DataList;
 use SilverStripe\GraphQL\Manager;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 /**
  * Decorator for either a Read or ReadOne query scaffolder
  *

--- a/_legacy/GraphQL/Extensions/SchemaScaffolderExtension.php
+++ b/_legacy/GraphQL/Extensions/SchemaScaffolderExtension.php
@@ -9,6 +9,12 @@ use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\Security\Member;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 /**
  * @deprecated 4.8..5.0 Use silverstripe/graphql:^4 functionality.
  */

--- a/_legacy/GraphQL/Operations/CopyToStage.php
+++ b/_legacy/GraphQL/Operations/CopyToStage.php
@@ -12,6 +12,8 @@ use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(MutationScaffolder::class)) {
     return;
 }

--- a/_legacy/GraphQL/Operations/Publish.php
+++ b/_legacy/GraphQL/Operations/Publish.php
@@ -7,6 +7,8 @@ use SilverStripe\Security\Member;
 use SilverStripe\Versioned\RecursivePublishable;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(PublishOperation::class)) {
     return;
 }

--- a/_legacy/GraphQL/Operations/PublishOperation.php
+++ b/_legacy/GraphQL/Operations/PublishOperation.php
@@ -15,6 +15,8 @@ use SilverStripe\ORM\ValidationException;
 use SilverStripe\Security\Member;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(MutationScaffolder::class)) {
     return;
 }

--- a/_legacy/GraphQL/Operations/ReadVersions.php
+++ b/_legacy/GraphQL/Operations/ReadVersions.php
@@ -9,6 +9,8 @@ use SilverStripe\GraphQL\Scaffolding\Scaffolders\ListQueryScaffolder;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(ListQueryScaffolder::class)) {
     return;
 }

--- a/_legacy/GraphQL/Operations/Rollback.php
+++ b/_legacy/GraphQL/Operations/Rollback.php
@@ -12,6 +12,8 @@ use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(MutationScaffolder::class)) {
     return;
 }

--- a/_legacy/GraphQL/Operations/Unpublish.php
+++ b/_legacy/GraphQL/Operations/Unpublish.php
@@ -7,6 +7,8 @@ use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\Security\Member;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(PublishOperation::class)) {
     return;
 }

--- a/_legacy/GraphQL/Resolvers/ApplyVersionFilters.php
+++ b/_legacy/GraphQL/Resolvers/ApplyVersionFilters.php
@@ -8,6 +8,12 @@ use SilverStripe\Versioned\Versioned;
 use InvalidArgumentException;
 use DateTime;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 /**
  * @deprecated 4.8..5.0 Use silverstripe/graphql:^4 functionality.
  */

--- a/_legacy/GraphQL/Types/CopyToStageInputType.php
+++ b/_legacy/GraphQL/Types/CopyToStageInputType.php
@@ -6,6 +6,8 @@ use GraphQL\Type\Definition\Type;
 use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\GraphQL\TypeCreator;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(TypeCreator::class)) {
     return;
 }

--- a/_legacy/GraphQL/Types/VersionSortType.php
+++ b/_legacy/GraphQL/Types/VersionSortType.php
@@ -7,6 +7,8 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\GraphQL\Pagination\SortDirectionTypeCreator;
 use SilverStripe\GraphQL\TypeCreator;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(TypeCreator::class)) {
     return;
 }

--- a/_legacy/GraphQL/Types/VersionedInputType.php
+++ b/_legacy/GraphQL/Types/VersionedInputType.php
@@ -7,6 +7,8 @@ use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\GraphQL\TypeCreator;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(TypeCreator::class)) {
     return;
 }

--- a/_legacy/GraphQL/Types/VersionedQueryMode.php
+++ b/_legacy/GraphQL/Types/VersionedQueryMode.php
@@ -6,6 +6,8 @@ use GraphQL\Type\Definition\EnumType;
 use SilverStripe\GraphQL\TypeCreator;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(TypeCreator::class)) {
     return;
 }

--- a/_legacy/GraphQL/Types/VersionedStage.php
+++ b/_legacy/GraphQL/Types/VersionedStage.php
@@ -6,6 +6,8 @@ use GraphQL\Type\Definition\EnumType;
 use SilverStripe\GraphQL\TypeCreator;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(TypeCreator::class)) {
     return;
 }

--- a/_legacy/GraphQL/Types/VersionedStatus.php
+++ b/_legacy/GraphQL/Types/VersionedStatus.php
@@ -5,6 +5,8 @@ namespace SilverStripe\Versioned\GraphQL\Types;
 use GraphQL\Type\Definition\EnumType;
 use SilverStripe\GraphQL\TypeCreator;
 
+// GraphQL dependency is optional in versioned,
+// and legacy implementation relies on existence of this class (in GraphQL v3)
 if (!class_exists(TypeCreator::class)) {
     return;
 }

--- a/src/GraphQL/Operations/AbstractPublishOperationCreator.php
+++ b/src/GraphQL/Operations/AbstractPublishOperationCreator.php
@@ -24,6 +24,8 @@ use SilverStripe\Security\Member;
 use SilverStripe\Versioned\GraphQL\Resolvers\VersionedResolver;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
 if (!interface_exists(OperationCreator::class)) {
     return;
 }

--- a/src/GraphQL/Operations/CopyToStageCreator.php
+++ b/src/GraphQL/Operations/CopyToStageCreator.php
@@ -13,6 +13,8 @@ use SilverStripe\GraphQL\Schema\Interfaces\SchemaModelInterface;
 use SilverStripe\Versioned\GraphQL\Resolvers\VersionedResolver;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
 if (!interface_exists(OperationCreator::class)) {
     return;
 }

--- a/src/GraphQL/Operations/PublishCreator.php
+++ b/src/GraphQL/Operations/PublishCreator.php
@@ -4,6 +4,8 @@ namespace SilverStripe\Versioned\GraphQL\Operations;
 
 use SilverStripe\GraphQL\Schema\Interfaces\OperationCreator;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
 if (!interface_exists(OperationCreator::class)) {
     return;
 }

--- a/src/GraphQL/Operations/RollbackCreator.php
+++ b/src/GraphQL/Operations/RollbackCreator.php
@@ -13,6 +13,8 @@ use SilverStripe\GraphQL\Schema\Interfaces\SchemaModelInterface;
 use SilverStripe\Versioned\GraphQL\Resolvers\VersionedResolver;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
 if (!interface_exists(OperationCreator::class)) {
     return;
 }

--- a/src/GraphQL/Operations/UnpublishCreator.php
+++ b/src/GraphQL/Operations/UnpublishCreator.php
@@ -4,6 +4,8 @@ namespace SilverStripe\Versioned\GraphQL\Operations;
 
 use SilverStripe\GraphQL\Schema\Interfaces\OperationCreator;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
 if (!interface_exists(OperationCreator::class)) {
     return;
 }

--- a/src/GraphQL/Plugins/UnpublishOnDelete.php
+++ b/src/GraphQL/Plugins/UnpublishOnDelete.php
@@ -15,6 +15,8 @@ use SilverStripe\Versioned\Versioned;
 use Exception;
 use Closure;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
 if (!interface_exists(ModelMutationPlugin::class)) {
     return;
 }

--- a/src/GraphQL/Plugins/VersionedDataObject.php
+++ b/src/GraphQL/Plugins/VersionedDataObject.php
@@ -19,6 +19,8 @@ use SilverStripe\Versioned\GraphQL\Resolvers\VersionedResolver;
 use SilverStripe\Versioned\Versioned;
 use Closure;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
 if (!interface_exists(ModelTypePlugin::class)) {
     return;
 }

--- a/src/GraphQL/Plugins/VersionedRead.php
+++ b/src/GraphQL/Plugins/VersionedRead.php
@@ -10,6 +10,8 @@ use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\Versioned\GraphQL\Resolvers\VersionedResolver;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
 if (!interface_exists(ModelQueryPlugin::class)) {
     return;
 }

--- a/src/GraphQL/Resolvers/VersionedResolver.php
+++ b/src/GraphQL/Resolvers/VersionedResolver.php
@@ -22,6 +22,8 @@ use Exception;
 use Closure;
 use InvalidArgumentException;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
 if (!class_exists(DefaultResolverProvider::class)) {
     return;
 }

--- a/tests/php/GraphQL/Fake/FakeResolveInfo.php
+++ b/tests/php/GraphQL/Fake/FakeResolveInfo.php
@@ -5,6 +5,12 @@ namespace SilverStripe\Versioned\Tests\GraphQL\Fake;
 
 use GraphQL\Type\Definition\ResolveInfo;
 
+// GraphQL dependency is optional in versioned,
+// and the follow implementation relies on existence of this class (in GraphQL v4)
+if (!class_exists(ResolveInfo::class)) {
+    return;
+}
+
 class FakeResolveInfo extends ResolveInfo
 {
     public function __construct()

--- a/tests/php/GraphQL/Legacy/Extensions/DataObjectScaffolderExtensionTest.php
+++ b/tests/php/GraphQL/Legacy/Extensions/DataObjectScaffolderExtensionTest.php
@@ -13,6 +13,12 @@ use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Tests\VersionedTest\UnversionedWithField;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class DataObjectScaffolderExtensionTest extends SapphireTest
 {
     public static $extra_dataobjects = [
@@ -22,7 +28,7 @@ class DataObjectScaffolderExtensionTest extends SapphireTest
     protected function setUp()
     {
         parent::setUp();
-        if (class_exists(Schema::class)) {
+        if (!class_exists(Manager::class)) {
             $this->markTestSkipped('Skipped GraphQL 3 test ' . __CLASS__);
         }
     }

--- a/tests/php/GraphQL/Legacy/Extensions/ReadExtensionTest.php
+++ b/tests/php/GraphQL/Legacy/Extensions/ReadExtensionTest.php
@@ -15,6 +15,12 @@ use SilverStripe\Versioned\GraphQL\Types\VersionedInputType;
 use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Core\Injector\Injector;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class ReadExtensionTest extends SapphireTest
 {
 
@@ -25,7 +31,7 @@ class ReadExtensionTest extends SapphireTest
     protected function setUp()
     {
         parent::setUp();
-        if (class_exists(Schema::class)) {
+        if (!class_exists(Manager::class)) {
             $this->markTestSkipped('Skipped GraphQL 3 test ' . __CLASS__);
         }
     }

--- a/tests/php/GraphQL/Legacy/Extensions/ReadOneExtensionTest.php
+++ b/tests/php/GraphQL/Legacy/Extensions/ReadOneExtensionTest.php
@@ -15,6 +15,12 @@ use SilverStripe\Versioned\GraphQL\Types\VersionedInputType;
 use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class ReadOneExtensionTest extends SapphireTest
 {
     protected $usesDatabase = true;

--- a/tests/php/GraphQL/Legacy/Extensions/SchemaScaffolderExtensionTest.php
+++ b/tests/php/GraphQL/Legacy/Extensions/SchemaScaffolderExtensionTest.php
@@ -15,6 +15,12 @@ use SilverStripe\Versioned\Tests\VersionedTest\ChangeSetFake;
 use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Tests\VersionedTest\UnversionedWithField;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class SchemaScaffolderExtensionTest extends SapphireTest
 {
 

--- a/tests/php/GraphQL/Legacy/Operations/CopyToStageTest.php
+++ b/tests/php/GraphQL/Legacy/Operations/CopyToStageTest.php
@@ -16,6 +16,12 @@ use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Versioned;
 use InvalidArgumentException;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class CopyToStageTest extends SapphireTest
 {
 

--- a/tests/php/GraphQL/Legacy/Operations/PublishTest.php
+++ b/tests/php/GraphQL/Legacy/Operations/PublishTest.php
@@ -15,6 +15,12 @@ use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Versioned;
 use Exception;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class PublishTest extends SapphireTest
 {
     protected $usesDatabase = true;

--- a/tests/php/GraphQL/Legacy/Operations/ReadVersionsTest.php
+++ b/tests/php/GraphQL/Legacy/Operations/ReadVersionsTest.php
@@ -17,6 +17,12 @@ use SilverStripe\Versioned\GraphQL\Types\VersionSortType;
 use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Tests\VersionedTest\UnversionedWithField;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class ReadVersionsTest extends SapphireTest
 {
 

--- a/tests/php/GraphQL/Legacy/Operations/RollbackTest.php
+++ b/tests/php/GraphQL/Legacy/Operations/RollbackTest.php
@@ -14,6 +14,12 @@ use SilverStripe\Security\Security;
 use SilverStripe\Versioned\GraphQL\Operations\Rollback;
 use SilverStripe\Versioned\Tests\GraphQL\Fake\FakeDataObjectStub;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class RollbackTest extends SapphireTest
 {
     protected $usesDatabase = true;

--- a/tests/php/GraphQL/Legacy/Operations/UnpublishTest.php
+++ b/tests/php/GraphQL/Legacy/Operations/UnpublishTest.php
@@ -15,6 +15,12 @@ use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Versioned;
 use Exception;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class UnpublishTest extends SapphireTest
 {
 

--- a/tests/php/GraphQL/Legacy/Resolvers/ApplyVersionFiltersTest.php
+++ b/tests/php/GraphQL/Legacy/Resolvers/ApplyVersionFiltersTest.php
@@ -9,6 +9,12 @@ use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and this legacy implementation relies on existence of this class (in GraphQL v3)
+if (!class_exists(Manager::class)) {
+    return;
+}
+
 class ApplyVersionFiltersTest extends SapphireTest
 {
     protected $usesDatabase = true;

--- a/tests/php/GraphQL/Plugins/VersionedDataObjectPluginTest.php
+++ b/tests/php/GraphQL/Plugins/VersionedDataObjectPluginTest.php
@@ -26,6 +26,12 @@ use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Tests\VersionedTest\UnversionedWithField;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
+if (!class_exists(Schema::class)) {
+    return;
+}
+
 class VersionedDataObjectPluginTest extends SapphireTest
 {
     protected static $extra_dataobjects = [

--- a/tests/php/GraphQL/Plugins/VersionedReadTest.php
+++ b/tests/php/GraphQL/Plugins/VersionedReadTest.php
@@ -24,6 +24,12 @@ use SilverStripe\Versioned\GraphQL\Types\VersionedInputType;
 use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Versioned;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
+if (!class_exists(Schema::class)) {
+    return;
+}
+
 class VersionedReadTest extends SapphireTest
 {
     protected function setUp()

--- a/tests/php/GraphQL/Resolvers/VersionedFiltersTest.php
+++ b/tests/php/GraphQL/Resolvers/VersionedFiltersTest.php
@@ -9,6 +9,12 @@ use SilverStripe\Versioned\Tests\GraphQL\Fake\Fake;
 use SilverStripe\Versioned\Versioned;
 use InvalidArgumentException;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
+if (!class_exists(Schema::class)) {
+    return;
+}
+
 class VersionedFiltersTest extends SapphireTest
 {
     protected $usesDatabase = true;

--- a/tests/php/GraphQL/Resolvers/VersionedResolverTest.php
+++ b/tests/php/GraphQL/Resolvers/VersionedResolverTest.php
@@ -16,6 +16,12 @@ use SilverStripe\Versioned\Versioned;
 use InvalidArgumentException;
 use Exception;
 
+// GraphQL dependency is optional in versioned,
+// and the following implementation relies on existence of this class (in GraphQL v4)
+if (!class_exists(Schema::class)) {
+    return;
+}
+
 class VersionedResolverTest extends SapphireTest
 {
     protected $usesDatabase = true;


### PR DESCRIPTION
versioned has require-dev with "silverstripe/graphql": "3.x-dev || 4.x-dev".
framework requires versioned.
require-dev only kicks in for root requirements.
versioned GraphQL implementation and tests have some if(!class_exists(<graphql-class>)) return false which prevents issues when installing versioned without GraphQL
versioned also uses this to distinguish between implementations and tests relying on GraphQL v3 and v4 classes
This isn’t consistently implemented in versioned

So if you do a composer create-project silverstripe/framework . && vendor/bin/phpunit, it’ll fail tests because it’s missing classes. My assumption is that we don’t want to make make GraphQL a hard requirement of versioned, so I’m implementing the class_exists() checks consistently.