### PR TITLE
MNT Remove explicit Symfony cache dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "silverstripe/framework": "^4.7",
-        "silverstripe/vendor-plugin": "^1",
-        "symfony/cache": "^3.4"
+        "symfony/cache": "^3.4 || ^4",
+        "silverstripe/vendor-plugin": "^1"
     },
     "require-dev": {
         "sminnee/phpunit": "^5.7",


### PR DESCRIPTION
Rely on the framework requirements instead.

Resolves https://github.com/silverstripe/silverstripe-versioned/issues/321