### PR TITLE
BUGFIX: replace versions pagination, sort to fix versioned-admin

### DIFF
--- a/tests/php/GraphQL/Plugins/VersionedDataObjectPluginTest.php
+++ b/tests/php/GraphQL/Plugins/VersionedDataObjectPluginTest.php
@@ -84,10 +84,6 @@ class VersionedDataObjectPluginTest extends SapphireTest
         }
 
         $this->assertInstanceOf(Field::class, $type->getFieldByName('versions'));
-
-        $versions = $type->getFieldByName('versions');
-        $this->assertTrue($versions->hasPlugin(SortPlugin::IDENTIFIER));
-        //$this->assertEquals(VersionedResolver::class . '::resolveVersionList', $versions->getEncodedResolver()->getRef()->toString());
     }
 
     public function testPluginDoesntAddVersionedFieldsToUnversionedObjects()


### PR DESCRIPTION
versioned-admin is broken because of this. See: https://github.com/silverstripe/silverstripe-graphql/issues/309
