### PR TITLE
Don't run queries when trying to retrieve versions for unsaved records

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2100,11 +2100,18 @@ SQL
      */
     public function allVersions($filter = "", $sort = "", $limit = "", $join = "", $having = "")
     {
+        /** @var DataObject $owner */
+        $owner = $this->owner;
+
+        // When an object is not yet in the Database, we can't get its versions
+        if (!$owner->isInDB()) {
+            return ArrayList::create();
+        }
+
         // Make sure the table names are not postfixed (e.g. _Live)
         $oldMode = static::get_reading_mode();
         static::set_stage(static::DRAFT);
 
-        $owner = $this->owner;
         $list = DataObject::get(DataObject::getSchema()->baseDataClass($owner), $filter, $sort, $join, $limit);
         if ($having) {
             // @todo - This method doesn't exist on DataList

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -893,6 +893,15 @@ class VersionedTest extends SapphireTest
         $this->assertEquals($extraFields, ['2005', '2007', '2009'], 'Additional version fields returned');
     }
 
+    public function testAllVersionsOnUnsavedRecord()
+    {
+        $newPage = new VersionedTest\Subclass();
+        $this->assertCount(0, $newPage->allVersions(), 'No versions on unsaved record');
+
+        $singleton = VersionedTest\Subclass::singleton();
+        $this->assertCount(0, $singleton->allVersions(), 'No versions for singleton');
+    }
+
     public function testArchiveRelatedDataWithoutVersioned()
     {
         DBDatetime::set_mock_now('2009-01-01 00:00:00');


### PR DESCRIPTION
Right now if you call `allVersions` on a singleton DataObject, it will try to run a query ... which is nonsensical. This is causing grievances to our graphql `--no-database` build steps.

# Parent issue
- ~~https://github.com/silverstripe/silverstripe-graphql/issues/445~~
- #353