### PR TITLE
FIX: Make ReadVersions injectable

### DIFF
--- a/_legacy/GraphQL/Extensions/DataObjectScaffolderExtension.php
+++ b/_legacy/GraphQL/Extensions/DataObjectScaffolderExtension.php
@@ -108,7 +108,7 @@ class DataObjectScaffolderExtension extends Extension
         // With the version type in the manager now, add the versioning fields to the dataobject type
         $owner
             ->addFields([$version])
-            ->nestedQuery($versions, new ReadVersions($class, $versionName));
+            ->nestedQuery($versions, ReadVersions::create($class, $versionName));
     }
 
     /**

--- a/_legacy/GraphQL/Operations/ReadVersions.php
+++ b/_legacy/GraphQL/Operations/ReadVersions.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Versioned\GraphQL\Operations;
 
 use Exception;
+use SilverStripe\Core\Injector\Injectable;
 use GraphQL\Type\Definition\ResolveInfo;
 use SilverStripe\GraphQL\OperationResolver;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\ListQueryScaffolder;
@@ -22,6 +23,7 @@ if (!class_exists(ListQueryScaffolder::class)) {
  */
 class ReadVersions extends ListQueryScaffolder implements OperationResolver
 {
+    use Injectable;
     /**
      * ReadOperationScaffolder constructor.
      *


### PR DESCRIPTION
Replaces the `new` keyword with `::create` and makes ReadVersions injectable. 