### PR TITLE
Rescue Master Branch Commit ENH Prefer `::class` syntax over class strings

### DIFF
--- a/src/GridFieldRestoreAction.php
+++ b/src/GridFieldRestoreAction.php
@@ -126,11 +126,11 @@ class GridFieldRestoreAction implements GridField_ColumnProvider, GridField_Acti
             $restoreToRoot = RestoreAction::shouldRestoreToRoot($record);
 
             $title = $restoreToRoot
-                ? _t('SilverStripe\\Versioned\\RestoreAction.RESTORE_TO_ROOT', 'Restore to draft at top level')
-                : _t('SilverStripe\\Versioned\\RestoreAction.RESTORE', 'Restore to draft');
+                ? _t(RestoreAction::class . '.RESTORE_TO_ROOT', 'Restore to draft at top level')
+                : _t(RestoreAction::class . '.RESTORE', 'Restore to draft');
             $description = $restoreToRoot
-                ? _t('SilverStripe\\Versioned\\RestoreAction.RESTORE_TO_ROOT_DESC', 'Restore the archived version to draft as a top level item')
-                : _t('SilverStripe\\Versioned\\RestoreAction.RESTORE_DESC', 'Restore the archived version to draft');
+                ? _t(RestoreAction::class . '.RESTORE_TO_ROOT_DESC', 'Restore the archived version to draft as a top level item')
+                : _t(RestoreAction::class . '.RESTORE_DESC', 'Restore the archived version to draft');
 
             $field = GridField_FormAction::create(
                 $gridField,

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Versioned;
 
+use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Convert;
 use SilverStripe\Forms\FieldList;
@@ -323,7 +324,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
                 ->addExtraClass('btn-outline-primary font-icon-tick')
                 ->setAttribute('data-btn-alternate-add', 'btn-primary font-icon-save')
                 ->setAttribute('data-btn-alternate-remove', 'btn-outline-primary font-icon-tick')
-                ->setAttribute('data-text-alternate', _t('SilverStripe\\CMS\\Controllers\\CMSMain.SAVEDRAFT', 'Save draft'));
+                ->setAttribute('data-text-alternate', _t(CMSMain::class . '.SAVEDRAFT', 'Save draft'));
         }
 
         // "publish" action
@@ -370,8 +371,8 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             // Replace "delete" action
             $actions->removeByName('action_doDelete');
             $title = $isPublished
-                ? _t('SilverStripe\\CMS\\Controllers\\CMSMain.UNPUBLISH_AND_ARCHIVE', 'Unpublish and archive')
-                : _t('SilverStripe\\CMS\\Controllers\\CMSMain.ARCHIVE', 'Archive');
+                ? _t(CMSMain::class . '.UNPUBLISH_AND_ARCHIVE', 'Unpublish and archive')
+                : _t(CMSMain::class . '.ARCHIVE', 'Archive');
 
             $actionArchive = FormAction::create('doArchive', $title)
                 ->addExtraClass('delete btn btn-secondary')


### PR DESCRIPTION
Rescues and extends https://github.com/silverstripe/silverstripe-versioned/commit/43be1a09235507eb8472f1dc70d5586240ef145c

There's no change to API here so it makes sense to target `1` so both major lines can benefit.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350