### PR TITLE
API Symfony 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.1",
         "silverstripe/framework": "^5",
-        "symfony/cache": "^4",
+        "symfony/cache": "^6.1",
         "silverstripe/vendor-plugin": "^2"
     },
     "require-dev": {

--- a/src/Caching/ProxyCacheAdapter.php
+++ b/src/Caching/ProxyCacheAdapter.php
@@ -140,7 +140,7 @@ abstract class ProxyCacheAdapter implements CacheInterface, ResettableInterface,
     /**
      * {@inheritdoc}
      */
-    public function prune()
+    public function prune(): bool
     {
         if ($this->pool instanceof PruneableInterface) {
             return $this->pool->prune();


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10389

Fixes 
`PHP Fatal error:  Declaration of SilverStripe\Versioned\Caching\ProxyCacheAdapter::prune() must be compatible with Symfony\Component\Cache\PruneableInterface::prune(): bool in /var/www/vendor/silverstripe/versioned/src/Caching/ProxyCacheAdapter.php on line 143`