### PR TITLE
FIX Ensure sort is not empty

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2874,11 +2874,14 @@ SQL
      */
     public static function get_including_deleted($class, $filter = "", $sort = "")
     {
-        $list = DataList::create($class)
-            ->where($filter)
-            ->sort($sort)
-            ->setDataQueryParam("Versioned.mode", "latest_versions");
-
+        $list = DataList::create($class);
+        if (!empty($filter)) {
+            $list = $list->where($filter);
+        }
+        if (!empty($sort)) {
+            $list = $list->orderBy($sort);
+        }
+        $list = $list->setDataQueryParam("Versioned.mode", "latest_versions");
         return $list;
     }
 

--- a/tests/php/VersionedGridFieldTest/TestController.php
+++ b/tests/php/VersionedGridFieldTest/TestController.php
@@ -42,7 +42,7 @@ class TestController extends Controller implements TestOnly
     public function Form()
     {
         $objects = TestObject::get()
-            ->sort('"VersionedTest_DataObject"."ID" ASC');
+            ->orderBy('"VersionedTest_DataObject"."ID" ASC');
         $field = new GridField('testfield', 'testfield', $objects, GridFieldConfig_RelationEditor::create());
         return new Form($this, 'Form', new FieldList($field), new FieldList());
     }

--- a/tests/php/VersionedOwnershipTest.php
+++ b/tests/php/VersionedOwnershipTest.php
@@ -372,7 +372,7 @@ class VersionedOwnershipTest extends SapphireTest
 
         // Test that a changeset was created
         /** @var ChangeSet $changeset */
-        $changeset = ChangeSet::get()->sort('"ChangeSet"."ID" DESC')->first();
+        $changeset = ChangeSet::get()->orderBy('"ChangeSet"."ID" DESC')->first();
         $this->assertNotEmpty($changeset);
 
         // Test that this changeset is inferred
@@ -455,7 +455,7 @@ class VersionedOwnershipTest extends SapphireTest
 
         // Test that a changeset was created
         /** @var ChangeSet $changeset */
-        $changeset = ChangeSet::get()->sort('"ChangeSet"."ID" DESC')->first();
+        $changeset = ChangeSet::get()->orderBy('"ChangeSet"."ID" DESC')->first();
         $this->assertNotEmpty($changeset);
 
         // Test that this changeset is inferred

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -219,11 +219,9 @@ class VersionedTest extends SapphireTest
     public function testGetIncludingDeleted()
     {
         // Get all ids of pages
-        $allPageIDs = DataObject::get(
-            VersionedTest\TestObject::class,
-            "\"ParentID\" = 0",
-            "\"VersionedTest_DataObject\".\"ID\" ASC"
-        )->column('ID');
+        $allPageIDs = DataObject::get(VersionedTest\TestObject::class)
+            ->where("\"ParentID\" = 0")
+            ->orderBy("\"VersionedTest_DataObject\".\"ID\" ASC")->column('ID');
 
         // Modify a page, ensuring that the Version ID and Record ID will differ,
         // and then subsequently delete it
@@ -234,11 +232,9 @@ class VersionedTest extends SapphireTest
         $targetPage->delete();
 
         // Get all items, ignoring deleted
-        $remainingPages = DataObject::get(
-            VersionedTest\TestObject::class,
-            "\"ParentID\" = 0",
-            "\"VersionedTest_DataObject\".\"ID\" ASC"
-        );
+        $remainingPages = DataObject::get(VersionedTest\TestObject::class)
+            ->where("\"ParentID\" = 0")
+            ->orderBy("\"VersionedTest_DataObject\".\"ID\" ASC");
         // Check that page 3 has gone
         $this->assertNotNull($remainingPages);
         $this->assertEquals(["Page 1", "Page 2", "Subclass Page 1"], $remainingPages->column('Title'));


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10449

Requires https://github.com/silverstripe/silverstripe-framework/pull/10600 to be merged first - but this was run though an installer CI run: https://github.com/emteknetnz/silverstripe-installer/actions/runs/3617074332