### PR TITLE
FIX Handle a bool return type from DateTime::getLastErrors()

### DIFF
--- a/src/GraphQL/Resolvers/VersionFilters.php
+++ b/src/GraphQL/Resolvers/VersionFilters.php
@@ -221,7 +221,19 @@ class VersionFilters
     protected function isValidDate($date)
     {
         $dt = DateTime::createFromFormat('Y-m-d', $date);
-
-        return ($dt !== false && !array_sum($dt->getLastErrors() ?? []));
+        if ($dt === false) {
+            return false;
+        }
+        // DateTime::getLastErrors() has an undocumented difference pre PHP 8.2 for what's returned
+        // if there are no errors
+        // https://www.php.net/manual/en/datetime.getlasterrors.php
+        $errors = $dt->getLastErrors();
+        // PHP 8.2 - will return false if no errors
+        if ($errors === false) {
+            return true;
+        }
+        // PHP 8.2+ will only return an array containing a count of errors only if there are errors
+        // PHP < 8.2 will always return an array containing a count of errors even if there are no errors
+        return array_sum($errors) === 0;
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10403

Fixes `1) SilverStripe\Versioned\GraphQL\Resolvers\VersionedFiltersTest::testItSetsReadingStateByArchiveDate
TypeError: array_sum(): Argument #1 ($array) must be of type array, bool given`
https://github.com/emteknetnz/silverstripe-installer/actions/runs/3699031675/jobs/6265942969

[DateTime::getLastErrors()](https://www.php.net/manual/en/datetime.getlasterrors.php) will return false when there are no errors with the date parsed and `array_sum(false)` will throw the error above - I'm honestly not sure how this used to previously work.