### PR TITLE
API Deprecate Versions() having parameter

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -12,6 +12,7 @@ use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Resettable;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataExtension;
@@ -2002,11 +2003,20 @@ SQL
      * @param string $sort
      * @param string $limit
      * @param string $join Deprecated, use leftJoin($table, $joinClause) instead
-     * @param string $having
+     * @param string $having @deprecated 2.2.0 The $having parameter does nothing and will be removed without
+     *               equivalent functionality to replace it
      * @return ArrayList
      */
     public function Versions($filter = "", $sort = "", $limit = "", $join = "", $having = "")
     {
+        if ($having) {
+            Deprecation::withNoReplacement(function () {
+                $message = 'The $having parameter does nothing and will be removed without equivalent'
+                . ' functionality to replace it';
+                Deprecation::notice('2.2.0', $message);
+            });
+        }
+
         /** @var DataObject $owner */
         $owner = $this->owner;
 
@@ -2020,9 +2030,6 @@ SQL
         static::set_stage(static::DRAFT);
 
         $list = DataObject::get(DataObject::getSchema()->baseDataClass($owner), $filter, $sort, $join, $limit);
-        if ($having) {
-            $list->having($having);
-        }
 
         $query = $list->dataQuery()->query();
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-versioned/issues/417

Currently this parameter is used and if called could cause a hard error since the having() method doesn't exist on DataList

I'm not even sure why this paramater ever existed since I'm not sure how it could even be used in this context since you're calling DataList::get() and then passing through the $filter, $sort, $limit and $join paramaters ... though there doesn't seem like there's anyway to even use having since it's not creating a select SQL statement with an aggregate function like `count()` in it

Seems best to just prevent it from even attempting to call the non-existant DataList::having() and deprecate it
