### PR TITLE
ENH Respect new has_one config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.2",
         "symfony/cache": "^6.1",
         "silverstripe/vendor-plugin": "^2"
     },


### PR DESCRIPTION
`has_one` can now optionally have an array configuration to allow supporting multiple reciprocal `has_many` in a single `has_one` relation.

Note that a dependency bump is required since this is calling a new method. Tests won't be green until https://github.com/silverstripe/silverstripe-framework/pull/11084 is merged but an installer CI run is linked in the issue.

## PRs
- https://github.com/silverstripe/silverstripe-linkfield/issues/5