### PR TITLE
Properly use X-Status

### DIFF
--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -136,7 +136,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             'Archived {name} "{title}"',
             [
                 'name' => $record->i18n_singular_name(),
-                'title' => Convert::raw2xml($title)
+                'title' => $title
             ]
         );
         $this->setFormMessage($form, $message);
@@ -144,7 +144,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
         //when an item is deleted, redirect to the parent controller
         $controller = $this->getToplevelController();
         $controller->getRequest()->addHeader('X-Pjax', 'Content'); // Force a content refresh
-        $controller->getResponse()->addHeader('X-Status', $message);
+        $controller->getResponse()->addHeader('X-Status', rawurlencode($message));
         return $controller->redirect($this->getBackLink(), 302); //redirect back to admin section
     }
 
@@ -188,12 +188,12 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             'Published {type} "{title}"',
             [
                 'type' => $record->i18n_singular_name(),
-                'title' => Convert::raw2xml($record->Title)
+                'title' => $record->Title
             ]
         );
 
         $controller = $this->getToplevelController();
-        $controller->getResponse()->addHeader('X-Status', $message);
+        $controller->getResponse()->addHeader('X-Status', rawurlencode($message));
 
         return $this->redirectAfterSave($isNewRecord);
     }
@@ -222,13 +222,13 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             'Unpublished {name} "{title}"',
             [
                 'name' => $record->i18n_singular_name(),
-                'title' => Convert::raw2xml($title)
+                'title' => $title
             ]
         );
         $this->setFormMessage($form, $message);
 
         $controller = $this->getToplevelController();
-        $controller->getResponse()->addHeader('X-Status', $message);
+        $controller->getResponse()->addHeader('X-Status', rawurlencode($message));
 
         // Redirect back to edit
         return $this->redirectAfterSave(false);


### PR DESCRIPTION
Replaces https://github.com/silverstripe/silverstripe-versioned/pull/438

Follow up of
https://github.com/silverstripe/silverstripe-admin/pull/1640#pullrequestreview-1881274997

## Issues
https://github.com/silverstripe/silverstripe-framework/pull/11105
https://github.com/silverstripe/silverstripe-admin/issues/1639

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green