### PR TITLE
FIX Respect strict-typing of Factory interface

### DIFF
--- a/src/Caching/ProxyCacheFactory.php
+++ b/src/Caching/ProxyCacheFactory.php
@@ -20,7 +20,7 @@ class ProxyCacheFactory extends DefaultCacheFactory
      */
     protected $containerClass = null;
 
-    public function create($service, array $args = [])
+    public function create(string $service, array $args = []): CacheInterface
     {
         $backend = parent::create($service, $args);
 


### PR DESCRIPTION
Respects the new strict typing in https://github.com/silverstripe/silverstripe-framework/pull/11300
That PR is required for Ci to go green.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11145