### PR TITLE
API Delete deprecated canArchive method

### DIFF
--- a/src/GridFieldArchiveAction.php
+++ b/src/GridFieldArchiveAction.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\Versioned;
 
 use SilverStripe\Control\Controller;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridField_ActionMenuItem;
 use SilverStripe\Forms\GridField\GridField_ActionProvider;
@@ -12,6 +11,7 @@ use SilverStripe\Forms\GridField\GridField_FormAction;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
+use SilverStripe\View\ViewableData;
 
 /**
  * This class is a {@link GridField} component that replaces the delete action
@@ -177,8 +177,7 @@ class GridFieldArchiveAction implements GridField_ColumnProvider, GridField_Acti
                 return;
             }
 
-            $canArchive = Deprecation::withNoReplacement(fn() => $item->canArchive());
-            if (!$canArchive) {
+            if (!$item->canDelete()) {
                 throw new ValidationException(
                     _t(__CLASS__ . '.ArchivePermissionsFailure', "No archive permissions")
                 );
@@ -192,17 +191,13 @@ class GridFieldArchiveAction implements GridField_ColumnProvider, GridField_Acti
      * Returns the GridField_FormAction if archive can be performed
      *
      * @param GridField $gridField
-     * @param DataObject $record
+     * @param ViewableData $record
      * @return GridField_FormAction|null
      */
     public function getArchiveAction($gridField, $record)
     {
-        /* @var DataObject|Versioned $record */
-        if (!$record->hasMethod('canArchive')) {
-            return null;
-        }
-        $canArchive = Deprecation::withNoReplacement(fn() => $record->canArchive());
-        if (!$canArchive) {
+        /** @var ViewableData|Versioned $record */
+        if (!$record->has_extension(Versioned::class) || !$record->canDelete()) {
             return null;
         }
 

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -1494,51 +1494,19 @@ SQL
 
     /**
      * Check if the current user is allowed to archive this record.
-     * If extended, ensure that both canDelete and canUnpublish are extended also
      *
-     * @param Member $member
-     * @return bool
-     * @deprecated 5.3.0 Use canDelete() instead.
+     * We're intentionally using the canDelete check for archiving,
+     * since there's no concept of "deleting" a versioned record
+     * and having separate permission checks was confusing and easy
+     * to forget.
      */
-    public function canArchive($member = null)
+    public function canDelete($member = null): ?bool
     {
-        Deprecation::notice('5.3.0', 'Use canDelete() instead.');
-        if (!$member) {
-            $member = Security::getCurrentUser();
-        }
-
-        // Standard mechanism for accepting permission changes from extensions
-        $owner = $this->owner;
-        $extended = Deprecation::withNoReplacement(fn() => $owner->extendedCan('canArchive', $member));
-        if ($extended !== null) {
-            return $extended;
-        }
-
-        // Admin permissions allow
-        if (Permission::checkMember($member, "ADMIN")) {
-            return true;
-        }
-
-        // Check if this record can be deleted from stage
-        if (!$owner->canDelete($member)) {
+        // If the user isn't allowed to unpublish, they're definitely
+        // not allowed to archive live content.
+        if ($this->hasStages() && $this->isPublished() && !$this->getOwner()->canUnpublish($member)) {
             return false;
         }
-
-        // Check if we can delete from live
-        if (!$owner->canUnpublish($member)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @deprecated 5.3.0 Will be removed without equivalent functionality.
-     */
-    protected function extendCanArchive()
-    {
-        Deprecation::notice('5.3.0', 'Will be removed without equivalent functionality.');
-        // Prevent canArchive() extending itself
         return null;
     }
 
@@ -1827,7 +1795,7 @@ SQL
     /**
      * Removes the record from both live and stage
      *
-     * User code should call {@see canArchive()} prior to invoking this method.
+     * User code should call {@see canDelete()} prior to invoking this method.
      *
      * @return bool Success
      */

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -5,7 +5,6 @@ namespace SilverStripe\Versioned;
 use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Convert;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
@@ -119,8 +118,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
     {
         /** @var Versioned|DataObject $record */
         $record = $this->getRecord();
-        $canArchive = Deprecation::withNoReplacement(fn() => $record->canArchive());
-        if (!$canArchive) {
+        if (!$record->canDelete()) {
             return $this->httpError(403);
         }
 
@@ -295,7 +293,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
         $canPublish = $record->canPublish();
         $canUnpublish = $record->canUnpublish();
         $canEdit = $record->canEdit();
-        $canArchive = Deprecation::withNoReplacement(fn() => $record->canArchive());
+        $canDelete = $record->canDelete();
 
         // "save", supports an alternate state that is still clickable, but notifies the user that the action is not needed.
         $noChangesClasses = 'btn-outline-primary font-icon-tick';
@@ -379,7 +377,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
         }
 
         // "archive" action
-        if (($isOnDraft || $isPublished) && $canArchive) {
+        if (($isOnDraft || $isPublished) && $canDelete) {
             // Replace "delete" action
             $actions->removeByName('action_doDelete');
             $title = $isPublished


### PR DESCRIPTION
For versioned records, there is no concept of "deleting" the record - it's either being archived, unpublished, or in rare cases removed from draft but left published.

Previously the `canDelete()` method has been used to check if a record can be removed from draft specifically for versioned records - which is such a rare edge case it almost doesn't bare thinking about, especially given there's no way to do that purely by interacting with the UI, nor with the web API endpoints available in core or supported modules.

Instead, `canDelete()` is now to be used to check if the record can be archived. This reduces cognitive load for developers and is a step towards simplifying the overly-complex versioning system. This is also in keeping with other mechanisms, such as `cascade_deletes` which cascades archiving for versioned records.

Note that if the record has stages and is published, we don't allow users to archive if they can't unpublish.

## Issue
- https://github.com/silverstripe/silverstripe-versioned/issues/447