### PR TITLE
API Deprecate Versioned::canArchive()

### DIFF
--- a/src/GridFieldArchiveAction.php
+++ b/src/GridFieldArchiveAction.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Versioned;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridField_ActionMenuItem;
 use SilverStripe\Forms\GridField\GridField_ActionProvider;
@@ -176,7 +177,8 @@ class GridFieldArchiveAction implements GridField_ColumnProvider, GridField_Acti
                 return;
             }
 
-            if (!$item->canArchive()) {
+            $canArchive = Deprecation::withNoReplacement(fn() => $item->canArchive());
+            if (!$canArchive) {
                 throw new ValidationException(
                     _t(__CLASS__ . '.ArchivePermissionsFailure', "No archive permissions")
                 );
@@ -196,7 +198,11 @@ class GridFieldArchiveAction implements GridField_ColumnProvider, GridField_Acti
     public function getArchiveAction($gridField, $record)
     {
         /* @var DataObject|Versioned $record */
-        if (!$record->hasMethod('canArchive') || !$record->canArchive()) {
+        if (!$record->hasMethod('canArchive')) {
+            return null;
+        }
+        $canArchive = Deprecation::withNoReplacement(fn() => $record->canArchive());
+        if (!$canArchive) {
             return null;
         }
 

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -1498,16 +1498,18 @@ SQL
      *
      * @param Member $member
      * @return bool
+     * @deprecated 5.3.0 Use canDelete() instead.
      */
     public function canArchive($member = null)
     {
+        Deprecation::notice('5.3.0', 'Use canDelete() instead.');
         if (!$member) {
             $member = Security::getCurrentUser();
         }
 
         // Standard mechanism for accepting permission changes from extensions
         $owner = $this->owner;
-        $extended = $owner->extendedCan('canArchive', $member);
+        $extended = Deprecation::withNoReplacement(fn() => $owner->extendedCan('canArchive', $member));
         if ($extended !== null) {
             return $extended;
         }
@@ -1530,8 +1532,12 @@ SQL
         return true;
     }
 
+    /**
+     * @deprecated 5.3.0 Will be removed without equivalent functionality.
+     */
     protected function extendCanArchive()
     {
+        Deprecation::notice('5.3.0', 'Will be removed without equivalent functionality.');
         // Prevent canArchive() extending itself
         return null;
     }

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Versioned;
 use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Convert;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
@@ -118,7 +119,8 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
     {
         /** @var Versioned|DataObject $record */
         $record = $this->getRecord();
-        if (!$record->canArchive()) {
+        $canArchive = Deprecation::withNoReplacement(fn() => $record->canArchive());
+        if (!$canArchive) {
             return $this->httpError(403);
         }
 
@@ -293,7 +295,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
         $canPublish = $record->canPublish();
         $canUnpublish = $record->canUnpublish();
         $canEdit = $record->canEdit();
-        $canArchive = $record->canArchive();
+        $canArchive = Deprecation::withNoReplacement(fn() => $record->canArchive());
 
         // "save", supports an alternate state that is still clickable, but notifies the user that the action is not needed.
         $noChangesClasses = 'btn-outline-primary font-icon-tick';


### PR DESCRIPTION
For versioned records, there is no concept of "deleting" the record - it's either being archived, unpublished, or in rare cases removed from draft but left published.

Previously the `canDelete()` method has been used to check if a record can be removed from draft specifically for versioned records - which is such a rare edge case it almost doesn't bare thinking about, especially given there's no way to do that purely by interacting with the UI, nor with the web API endpoints available in core or supported modules.

Instead, `canDelete()` should be used to check if the record can be archived. This reduces cognitive load for developers and is a step towards simplifying the overly-complex versioning system. This is also in keeping with other mechanisms, such as `cascade_deletes` which cascades archiving for versioned records.

## Issue
- https://github.com/silverstripe/silverstripe-versioned/issues/447