### PR TITLE
FIX Respect new typehints

### DIFF
--- a/src/DataDifferencer.php
+++ b/src/DataDifferencer.php
@@ -112,7 +112,7 @@ class DataDifferencer extends ViewableData
             if (!($toField instanceof DBField)) {
                 continue;
             }
-            $toValue = $toField->forTemplate();
+            $toValue = $toField?->forTemplate();
 
             // Show only to value
             if (!$this->fromRecord) {
@@ -125,7 +125,7 @@ class DataDifferencer extends ViewableData
             if (!($fromField instanceof DBField)) {
                 continue;
             }
-            $fromValue = $fromField->forTemplate();
+            $fromValue = $fromField?->forTemplate();
 
             // Show changes between the two, if any exist
             if ($fromValue != $toValue) {
@@ -193,7 +193,7 @@ class DataDifferencer extends ViewableData
         }
 
         // Format title
-        return $object->obj('Title')->forTemplate();
+        return $object->obj('Title')?->forTemplate();
     }
 
     /**


### PR DESCRIPTION
Respects the fact that `obj()` can now return `null`.
There are other places where `obj()` is called that I have intentionally not updated, either because they won't cause problems or because they shouldn't fail silently.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11322