### PR TITLE
FIX Ensure no admin routed links are affected by versioning

### DIFF
--- a/src/VersionedStateExtension.php
+++ b/src/VersionedStateExtension.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\Versioned;
 
-use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\Admin\AdminController;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Extension;
@@ -51,7 +51,7 @@ class VersionedStateExtension extends Extension
         }
 
         // Don't touch Admin/CMS links
-        if (class_exists(LeftAndMain::class) && $this->getOwner() instanceof LeftAndMain) {
+        if (class_exists(AdminController::class) && $this->getOwner() instanceof AdminController) {
             return;
         }
 

--- a/tests/php/VersionedStateExtensionTest.php
+++ b/tests/php/VersionedStateExtensionTest.php
@@ -2,7 +2,11 @@
 
 namespace SilverStripe\Versioned\Tests;
 
+use SilverStripe\Admin\AdminController;
 use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Session;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Versioned\VersionedStateExtension;
@@ -63,18 +67,21 @@ class VersionedStateExtensionTest extends SapphireTest
         $this->assertEquals('item/myobject', $obj1Live->Link());
     }
 
-    public function testDontUpdateLeftAndMainLinks()
+    public function testDontUpdateAdminLinks()
     {
-        if (!class_exists(LeftAndMain::class)) {
-            $this->markTestSkipped('silverstripe/cms not installed');
+        if (!class_exists(AdminController::class)) {
+            $this->markTestSkipped('silverstripe/admin not installed');
             return;
         }
 
+        $request = new HTTPRequest('', '');
+        $request->setSession(new Session([]));
+        Injector::inst()->registerService($request, HTTPRequest::class);
         $controller = new LeftAndMain();
 
-        $liveClientConfig = $controller->getClientConfig();
+        $liveClientConfig = $controller->getCombinedClientConfig();
         Versioned::set_stage(Versioned::DRAFT);
-        $stageClientConfig = $controller->getClientConfig();
+        $stageClientConfig = $controller->getCombinedClientConfig();
 
         $this->assertEquals(
             $liveClientConfig,


### PR DESCRIPTION
This code was originally introduced in https://github.com/silverstripe/silverstripe-versioned/pull/173 and is intended to avoid adding stage params to any `admin/*` routed URL (which used to be theoretically restricted to LeftAndMain subclasses).

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1762