### PR TITLE
DEP Don't include vendor-plugin as an explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/framework": "^6",
-        "symfony/cache": "^7.0",
-        "silverstripe/vendor-plugin": "^2"
+        "symfony/cache": "^7.0"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^4",


### PR DESCRIPTION
We don't directly reference it in code or config, so we can rely on silverstripe/framework having this dependency for us.

## Issue
- https://github.com/silverstripe/.github/issues/311