### PR TITLE
FIX Escape user input from an HTML context.

### DIFF
--- a/src/RestoreAction.php
+++ b/src/RestoreAction.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Versioned;
 
+use SilverStripe\Core\Convert;
 use SilverStripe\ORM\Hierarchy\Hierarchy;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Versioned\Versioned;
@@ -86,7 +87,7 @@ class RestoreAction
     public static function getRestoreMessage($originalItem, $restoredItem, $changedLocation = false)
     {
         $restoredID = $restoredItem->Title ?: $restoredItem->ID;
-        $restoredType = strtolower($restoredItem->i18n_singular_name() ?? '');
+        $restoredType = Convert::raw2xml(strtolower($restoredItem->i18n_singular_name() ?? ''));
 
         if (method_exists($restoredItem, 'CMSEditLink') &&
         $restoredItem->CMSEditLink()) {

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -132,8 +132,8 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             __CLASS__ . '.Archived',
             'Archived {name} "{title}"',
             [
-                'name' => $record->i18n_singular_name(),
-                'title' => $title
+                'name' => Convert::raw2xml($record->i18n_singular_name()),
+                'title' => Convert::raw2xml($title)
             ]
         );
         $this->setFormMessage($form, $message);
@@ -174,7 +174,7 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             __CLASS__ . '.Published',
             'Published {name} {link}',
             [
-                'name' => $record->i18n_singular_name(),
+                'name' => Convert::raw2xml($record->i18n_singular_name()),
                 'link' => $link
             ]
         );
@@ -218,8 +218,8 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             __CLASS__ . '.Unpublished',
             'Unpublished {name} "{title}"',
             [
-                'name' => $record->i18n_singular_name(),
-                'title' => $title
+                'name' => Convert::raw2xml($record->i18n_singular_name()),
+                'title' => Convert::raw2xml($title)
             ]
         );
         $this->setFormMessage($form, $message);


### PR DESCRIPTION
There is no XSS vulnerability here due to other measures to mitigate one - but user input which includes HTML characters still might not render correctly without this fix.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/890 (private issue)