### PR TITLE
NEW Add new methods for querying data in various version modes

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -474,6 +474,12 @@ class Versioned extends Extension implements TemplateGlobalProvider, Resettable
             case 'archive':
                 $this->augmentSQLVersionedArchive($query, $dataQuery);
                 break;
+            case 'archive_only':
+                $this->augmentSQLVersionedArchiveOnly($query, $dataQuery);
+                break;
+            case 'removed_from_draft':
+                $this->augmentSQLVersionedRemovedFromDraft($query, $dataQuery);
+                break;
             case 'latest_version_single':
                 $this->augmentSQLVersionedLatestSingle($query, $dataQuery);
                 break;
@@ -742,6 +748,42 @@ SQL
             20,
             $params
         );
+    }
+
+    /**
+     * Only include records which are archived - that is they have been removed from both the draft and live stages.
+     */
+    protected function augmentSQLVersionedArchiveOnly(SQLSelect $query, DataQuery $dataQuery): void
+    {
+        $baseTable = $this->baseTable();
+        $liveTable = $this->stageTable($baseTable, Versioned::LIVE);
+
+        $query->addLeftJoin(
+            $liveTable,
+            "\"{$baseTable}\".\"ID\" = \"{$liveTable}\".\"ID\""
+        );
+        $query->addWhere("\"{$liveTable}\".\"ID\" IS NULL");
+
+        $this->augmentSQLVersionedRemovedFromDraft($query, $dataQuery);
+    }
+
+    /**
+     * Only include records which are removed from draft - these might be archived but might also still be in the live stage.
+     */
+    protected function augmentSQLVersionedRemovedFromDraft(SQLSelect $query, DataQuery $dataQuery): void
+    {
+        $baseTable = $this->baseTable();
+
+        // Join a temporary alias BaseTable_Draft, renaming this on execution to BaseTable
+        // See Versioned::augmentSQLVersioned() For reference on this alias
+        $query->addLeftJoin(
+            "{$baseTable}_Draft",
+            "\"{$baseTable}\".\"ID\" = \"{$baseTable}_Draft\".\"ID\""
+        );
+
+        $query->addWhere("\"{$baseTable}_Draft\".\"ID\" IS NULL");
+
+        $this->augmentSQLVersionedLatest($query, $dataQuery);
     }
 
     /**
@@ -2479,24 +2521,29 @@ SQL
      * @template T of DataObject
      * @param class-string<T> $class The name of the class.
      * @param string $stage The name of the stage.
-     * @param string $filter A filter to be inserted into the WHERE clause.
-     * @param string $sort A sort expression to be inserted into the ORDER BY clause.
-     * @param int $limit A limit on the number of records returned from the database.
      * @param string $containerClass The container class for the result set (default is DataList)
      *
      * @return DataList<T> A modified DataList designated to the specified stage
      */
     public static function get_by_stage(
-        $class,
-        $stage,
-        $filter = '',
-        $sort = '',
-        $limit = null,
-        $containerClass = DataList::class
-    ) {
-        ReadingMode::validateStage($stage);
+        string $class,
+        string $stage,
+        string|array $filter = '',
+        string|array|null $sort = '',
+        string|array|null $limit = null,
+        string $containerClass = DataList::class
+    ): DataList {
         $result = DataObject::get($class, $filter, $sort, $limit, $containerClass);
-        return $result->setDataQueryParam([
+        return static::updateListToAlsoIncludeStage($result, $stage);
+    }
+
+    /**
+     * Update an existing DataList to include records for a given stage.
+     */
+    public static function updateListToAlsoIncludeStage(DataList $list, string $stage): DataList
+    {
+        ReadingMode::validateStage($stage);
+        return $list->setDataQueryParam([
             'Versioned.mode' => 'stage',
             'Versioned.stage' => $stage
         ]);
@@ -2784,11 +2831,11 @@ SQL
      *
      * @template T of DataObject
      * @param class-string<T> $class
-     * @param string $filter
-     * @param string $sort
+     * @param string $filter Explicitly used in where clause as raw SQL - use with caution!
+     * @param string $sort Explicitly used in orderBy clause as raw SQL - use with caution!
      * @return DataList<T>
      */
-    public static function get_including_deleted($class, $filter = "", $sort = "")
+    public static function get_including_deleted(string $class, string|array $filter = '', string $sort = ''): DataList
     {
         $list = DataList::create($class);
         if (!empty($filter)) {
@@ -2797,8 +2844,78 @@ SQL
         if (!empty($sort)) {
             $list = $list->orderBy($sort);
         }
-        $list = $list->setDataQueryParam("Versioned.mode", "latest_versions");
-        return $list;
+        return static::updateListToAlsoIncludeDeleted($list);
+    }
+
+    /**
+     * Update a DataList to query the latest version of each record stored in the (class)_Versions tables.
+     *
+     * In particular, this will query deleted records as well as active ones.
+     */
+    public static function updateListToAlsoIncludeDeleted(DataList $list): DataList
+    {
+        return $list->setDataQueryParam('Versioned.mode', 'latest_versions');
+    }
+
+    /**
+     * Return the equivalent of a DataList::create() call, querying only records which have been removed
+     * from draft. This includes archived records and records which were published but have no draft record.
+     *
+     * @template T of DataObject
+     * @param class-string<T> $class
+     * @param string $where Explicitly used in where clause as raw SQL - use with caution!
+     * @param string $orderBy Explicitly used in orderBy clause as raw SQL - use with caution!
+     * @return DataList<T>
+     */
+    public static function getRemovedFromDraft(string $class, string|array $where = '', string $orderBy = ''): DataList
+    {
+        $list = DataList::create($class);
+        if (!empty($where)) {
+            $list = $list->where($where);
+        }
+        if (!empty($orderBy)) {
+            $list = $list->orderBy($orderBy);
+        }
+        return static::updateListToOnlyIncludeRemovedFromDraft($list);
+    }
+
+    /**
+     * Update a DataList to query only records which have been removed from draft.
+     * This includes archived records and records which were published but have no draft record.
+     */
+    public static function updateListToOnlyIncludeRemovedFromDraft(DataList $list): DataList
+    {
+        return $list->setDataQueryParam('Versioned.mode', 'removed_from_draft');
+    }
+
+    /**
+     * Return the equivalent of a DataList::create() call, querying only records which are archived
+     * (i.e. removed in both draft and live)
+     *
+     * @template T of DataObject
+     * @param class-string<T> $class
+     * @param string $where Explicitly used in where clause as raw SQL - use with caution!
+     * @param string $orderBy Explicitly used in orderBy clause as raw SQL - use with caution!
+     * @return DataList<T>
+     */
+    public static function getArchivedOnly(string $class, string|array $where = '', string $orderBy = ''): DataList
+    {
+        $list = DataList::create($class);
+        if (!empty($where)) {
+            $list = $list->where($where);
+        }
+        if (!empty($orderBy)) {
+            $list = $list->orderBy($orderBy);
+        }
+        return static::updateListToOnlyIncludeArchived($list);
+    }
+
+    /**
+     * Update a DataList to query only records which are archived (i.e. removed in both draft and live)
+     */
+    public static function updateListToOnlyIncludeArchived(DataList $list): DataList
+    {
+        return $list->setDataQueryParam('Versioned.mode', 'archive_only');
     }
 
     /**

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -42,6 +42,7 @@ class VersionedTest extends SapphireTest
         VersionedTest\PublicViaExtension::class,
         VersionedTest\CustomTable::class,
         VersionedTest\ChangeSetTestObject::class,
+        VersionedTest\NoFixtureModel::class,
     ];
 
     public function testUniqueIndexes()
@@ -217,8 +218,10 @@ class VersionedTest extends SapphireTest
 
     /**
      * Test Versioned::get_including_deleted()
+     * This test seems to be testing edge cases and some rippling effects.
+     * See testGetIncludingDeleted for a pure test of results from get_including_deleted()
      */
-    public function testGetIncludingDeleted()
+    public function testGetIncludingDeletedWithOtherStuff()
     {
         // Get all ids of pages
         $allPageIDs = DataObject::get(VersionedTest\TestObject::class)
@@ -1792,5 +1795,313 @@ class VersionedTest extends SapphireTest
         }
 
         $this->assertSame($expected, $record->getStatusFlags());
+    }
+
+    public static function provideGetByStage(): array
+    {
+        return [
+            'draft only' => [
+                'stage' => Versioned::DRAFT,
+                'expected' => [
+                    'draft only1',
+                    'draft only2',
+                    'published1',
+                    'published2',
+                    'modified1',
+                    'modified2',
+                ],
+            ],
+            'published' => [
+                'stage' => Versioned::LIVE,
+                'expected' => [
+                    'published1',
+                    'published2',
+                    'published3',
+                    'published4',
+                    'deleted on draft1',
+                    'deleted on draft2',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetByStage')]
+    public function testGetByStage(string $stage, array $expected): void
+    {
+        $this->prepareRecordsForVersionTests();
+        $results = Versioned::get_by_stage(VersionedTest\NoFixtureModel::class, $stage);
+        $this->assertSame($expected, $results->column('Title'));
+    }
+
+    public static function provideUpdateListToAlsoIncludeStage(): array
+    {
+        return [
+            'draft ends with 1' => [
+                'stage' => Versioned::DRAFT,
+                'filter' => [
+                    'Title:EndsWith' => '1',
+                ],
+                'expected' => [
+                    'draft only1',
+                    'published1',
+                    'modified1',
+                ],
+            ],
+            'draft ends with 2' => [
+                'stage' => Versioned::DRAFT,
+                'filter' => [
+                    'Title:EndsWith:not' => '1',
+                ],
+                'expected' => [
+                    'draft only2',
+                    'published2',
+                    'modified2',
+                ],
+            ],
+            'live ends with 1' => [
+                'stage' => Versioned::LIVE,
+                'filter' => [
+                    'Title:EndsWith' => '1',
+                ],
+                'expected' => [
+                    'published1',
+                    'deleted on draft1',
+                ],
+            ],
+            'live ends with 2' => [
+                'stage' => Versioned::LIVE,
+                'filter' => [
+                    'Title:EndsWith:not' => '1',
+                ],
+                'expected' => [
+                    'published2',
+                    'published3',
+                    'published4',
+                    'deleted on draft2',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideUpdateListToAlsoIncludeStage')]
+    public function testUpdateListToAlsoIncludeStage(string $stage, array $filter, array $expected): void
+    {
+        $this->prepareRecordsForVersionTests();
+        $list = VersionedTest\NoFixtureModel::get()->filter($filter);
+        $results = Versioned::updateListToAlsoIncludeStage($list, $stage);
+        $this->assertSame($expected, $results->column('Title'));
+    }
+
+    public function testGetIncludingDeleted(): void
+    {
+        // @TODO make sure this is at least as robust as the old test with this name
+        $expected = [
+            'draft only1',
+            'draft only2',
+            'published1',
+            'published2',
+            'modified1',
+            'modified2',
+            'archived1',
+            'archived2',
+            'deleted on draft1',
+            'deleted on draft2',
+        ];
+
+        $this->prepareRecordsForVersionTests();
+        $results = Versioned::get_including_deleted(VersionedTest\NoFixtureModel::class);
+        $this->assertSame($expected, $results->column('Title'));
+    }
+
+    public static function provideUpdateListToAlsoIncludeDeleted(): array
+    {
+        return [
+            [
+                'filter' => [
+                    'Title:EndsWith' => '1',
+                ],
+                'expected' => [
+                    'draft only1',
+                    'published1',
+                    'modified1',
+                    'archived1',
+                    'deleted on draft1',
+                ],
+            ],
+            [
+                'filter' => [
+                    'Title:EndsWith:not' => '1',
+                ],
+                'expected' => [
+                    'draft only2',
+                    'published2',
+                    'modified2',
+                    'archived2',
+                    'deleted on draft2',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideUpdateListToAlsoIncludeDeleted')]
+    public function testUpdateListToAlsoIncludeDeleted(array $filter, array $expected): void
+    {
+        $this->prepareRecordsForVersionTests();
+        $list = VersionedTest\NoFixtureModel::get()->filter($filter);
+        $results = Versioned::updateListToAlsoIncludeDeleted($list);
+        $this->assertSame($expected, $results->column('Title'));
+    }
+
+    public function testGetRemovedFromDraft(): void
+    {
+        $expected = [
+            'archived1',
+            'archived2',
+            'deleted on draft1',
+            'deleted on draft2',
+        ];
+
+        $this->prepareRecordsForVersionTests();
+        $results = Versioned::getRemovedFromDraft(VersionedTest\NoFixtureModel::class);
+        $this->assertSame($expected, $results->column('Title'));
+    }
+
+    public static function provideUpdateListToOnlyIncludeRemovedFromDraft(): array
+    {
+        return [
+            [
+                'filter' => [
+                    'Title:EndsWith' => '1',
+                ],
+                'expected' => [
+                    'archived1',
+                    'deleted on draft1',
+                ],
+            ],
+            [
+                'filter' => [
+                    'Title:EndsWith:not' => '1',
+                ],
+                'expected' => [
+                    'archived2',
+                    'deleted on draft2',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideUpdateListToOnlyIncludeRemovedFromDraft')]
+    public function testUpdateListToOnlyIncludeRemovedFromDraft(array $filter, array $expected): void
+    {
+        $this->prepareRecordsForVersionTests();
+        $list = VersionedTest\NoFixtureModel::get()->filter($filter);
+        $results = Versioned::updateListToOnlyIncludeRemovedFromDraft($list);
+        $this->assertSame($expected, $results->column('Title'));
+    }
+
+    public function testGetArchivedOnly(): void
+    {
+        $expected = [
+            'archived1',
+            'archived2',
+        ];
+
+        $this->prepareRecordsForVersionTests();
+        $results = Versioned::getArchivedOnly(VersionedTest\NoFixtureModel::class);
+        $this->assertSame($expected, $results->column('Title'));
+    }
+
+
+    public static function provideUpdateListToOnlyIncludeArchived(): array
+    {
+        return [
+            [
+                'filter' => [
+                    'Title:EndsWith' => '1',
+                ],
+                'expected' => [
+                    'archived1',
+                ],
+            ],
+            [
+                'filter' => [
+                    'Title:EndsWith:not' => '1',
+                ],
+                'expected' => [
+                    'archived2',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideUpdateListToOnlyIncludeArchived')]
+    public function testUpdateListToOnlyIncludeArchived(array $filter, array $expected): void
+    {
+        $this->prepareRecordsForVersionTests();
+        $list = VersionedTest\NoFixtureModel::get()->filter($filter);
+        $results = Versioned::updateListToOnlyIncludeArchived($list);
+        $this->assertSame($expected, $results->column('Title'));
+    }
+
+    /**
+     * Prepares records in a bunch of different versioned states.
+     *
+     * We avoid using fixtures here because we're interested explicitly in how records in version tables interact with these methods.
+     * Using fixtures would mean we have to perform most of these operations in PHP anyway, with a little less control since some steps
+     * would be done before we get to touch the records.
+     */
+    private function prepareRecordsForVersionTests(): void
+    {
+        // Make some records that will only be on draft
+        $draftRecord1 = new VersionedTest\NoFixtureModel();
+        $draftRecord1->Title = 'draft only1';
+        $draftRecord1->write();
+        $draftRecord2 = new VersionedTest\NoFixtureModel();
+        $draftRecord2->Title = 'draft only2';
+        $draftRecord2->write();
+        // Make some records that will be published (live)
+        $publishedRecord1 = new VersionedTest\NoFixtureModel();
+        $publishedRecord1->Title = 'published1';
+        $publishedRecord1->write();
+        $publishedRecord1->publishSingle();
+        $publishedRecord2 = new VersionedTest\NoFixtureModel();
+        $publishedRecord2->Title = 'published2';
+        $publishedRecord2->write();
+        $publishedRecord2->publishSingle();
+        // Make some records to be "modified on draft"
+        $modifiedRecord1 = new VersionedTest\NoFixtureModel();
+        $modifiedRecord1->Title = 'published3';
+        $modifiedRecord1->write();
+        $modifiedRecord1->publishSingle();
+        $modifiedRecord1->Title = 'modified1';
+        $modifiedRecord1->write();
+        $modifiedRecord2 = new VersionedTest\NoFixtureModel();
+        $modifiedRecord2->Title = 'published4';
+        $modifiedRecord2->write();
+        $modifiedRecord2->publishSingle();
+        $modifiedRecord2->Title = 'modified2';
+        $modifiedRecord2->write();
+        // Make some records to be archived
+        $archivedRecord1 = new VersionedTest\NoFixtureModel();
+        $archivedRecord1->Title = 'archived1';
+        $archivedRecord1->write();
+        $archivedRecord1->publishSingle();
+        $archivedRecord1->doArchive();
+        $archivedRecord2 = new VersionedTest\NoFixtureModel();
+        $archivedRecord2->Title = 'archived2';
+        $archivedRecord2->write();
+        $archivedRecord2->publishSingle();
+        $archivedRecord2->doArchive();
+        // Make some records to be on LIVE but not on DRAFT
+        $noDraftRecord1 = new VersionedTest\NoFixtureModel();
+        $noDraftRecord1->Title = 'deleted on draft1';
+        $noDraftRecord1->write();
+        $noDraftRecord1->publishSingle();
+        $noDraftRecord1->deleteFromStage(Versioned::DRAFT);
+        $noDraftRecord2 = new VersionedTest\NoFixtureModel();
+        $noDraftRecord2->Title = 'deleted on draft2';
+        $noDraftRecord2->write();
+        $noDraftRecord2->publishSingle();
+        $noDraftRecord2->deleteFromStage(Versioned::DRAFT);
     }
 }

--- a/tests/php/VersionedTest/NoFixtureModel.php
+++ b/tests/php/VersionedTest/NoFixtureModel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\VersionedTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * DO NOT make fixtures with this model.
+ * We need to create all its records from scratch to ensure we don't get fixture results when we don't expect them.
+ * This is important because we're fetching things like archived and deleted records, so we can't just create and then
+ * delete the fixtures.
+ */
+class NoFixtureModel extends DataObject implements TestOnly
+{
+    private static $table_name = 'VersionedTest_NoFixtureModel';
+
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static $extensions = [
+        Versioned::class,
+    ];
+}


### PR DESCRIPTION
Needed to convert existing CMSSiteTreeFilter implementations from using filterByCallback() to instead perform all filtering inside the database.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2949