### PR TITLE
ENH Cache non-existant versions as zero

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2509,8 +2509,21 @@ SQL
 
         $versions = DB::prepared_query("SELECT \"ID\", \"Version\" FROM \"$stageTable\" $filter", $parameters)->map();
 
-        foreach ($versions as $id => $version) {
-            Versioned::$cache_versionnumber[$baseClass][$stage][$id] = $version;
+        if ($idList) {
+            foreach ($idList as $id) {
+                $version = 0;
+                foreach ($versions as $vid => $val) {
+                    if ($id === $vid) {
+                        $version = $val;
+                        break;
+                    }
+                }
+                Versioned::$cache_versionnumber[$baseClass][$stage][$id] = $version;
+            }
+        } else {
+            foreach ($versions as $id => $version) {
+                Versioned::$cache_versionnumber[$baseClass][$stage][$id] = $version;
+            }
         }
 
         $className = $class instanceof DataObject ? $class->ClassName : $class;


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11703

While working on https://github.com/silverstripe/silverstripe-asset-admin/pull/1560 I realised that missing versions e.g. unpublished live records, aren't cached as zero, therefore the caching doesn't actually do anything

0 is used to denote missing records already here https://github.com/silverstripe/silverstripe-versioned/blob/2/src/Versioned.php#L2448