### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "symfony/cache": "^7.0"
     },
     "require-dev": {

--- a/src/ChangeSetItem.php
+++ b/src/ChangeSetItem.php
@@ -181,7 +181,7 @@ class ChangeSetItem extends DataObject implements Thumbnail
 
         // Ignore stage for unversioned objects
         if (!$this->isVersioned()) {
-            return DataObject::get_by_id($this->ObjectClass, $this->ObjectID);
+            return DataObject::get($this->ObjectClass)->setUseCache(true)->byID($this->ObjectID);
         }
 
         // Get versioned object
@@ -201,7 +201,7 @@ class ChangeSetItem extends DataObject implements Thumbnail
 
         // Ignore version for unversioned objects
         if (!$this->isVersioned()) {
-            return DataObject::get_by_id($this->ObjectClass, $this->ObjectID);
+            return DataObject::get($this->ObjectClass)->setUseCache(true)->byID($this->ObjectID);
         }
 
         // Get versioned object

--- a/src/RecursiveStagesService.php
+++ b/src/RecursiveStagesService.php
@@ -115,7 +115,7 @@ class RecursiveStagesService implements RecursiveStagesInterface, Resettable
         $identifiers = Versioned::withVersionedMode(function () use ($object, $stage): array {
             Versioned::set_stage($stage);
 
-            $stagedObject = DataObject::get_by_id($object->ClassName, $object->ID);
+            $stagedObject = DataObject::get($object->ClassName)->setUseCache(true)->byID($object->ID);
 
             if ($stagedObject === null) {
                 return [];

--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2407,7 +2407,14 @@ SQL
     {
         return static::withVersionedMode(function () use ($class, $stage, $filter, $cache, $sort) {
             Versioned::set_stage($stage);
-            return DataObject::get_one($class, $filter, $cache, $sort);
+            $list = DataObject::get($class)->setUseCache($cache);
+            if (!empty($filter)) {
+                $list = $list->where($filter);
+            }
+            if (!empty($sort) || is_null($sort)) {
+                $list = $list->sort($sort);
+            }
+            return $list->first();
         });
     }
 
@@ -3061,7 +3068,7 @@ SQL
         if (!$this->owner->AuthorID) {
             return null;
         }
-        $member = DataObject::get_by_id(Member::class, $this->owner->AuthorID);
+        $member = Member::get()->setUseCache(true)->byID($this->owner->AuthorID);
         return $member;
     }
     /**
@@ -3075,7 +3082,7 @@ SQL
         if (!$this->owner->PublisherID) {
             return null;
         }
-        $member = DataObject::get_by_id(Member::class, $this->owner->PublisherID);
+        $member = Member::get()->setUseCache(true)->byID($this->owner->PublisherID);
         return $member;
     }
 


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
