### PR TITLE
FIX Don't try to set values for generated columns

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -1188,12 +1188,14 @@ SQL
         }
         if ($data) {
             $fields = $schema->databaseFields($class, false);
+            $generatedColumns = $schema->generatedFields($class, false);
             if (is_array($fields)) {
                 $data = array_intersect_key($data ?? [], $fields);
 
                 foreach ($data as $k => $v) {
                     // If the value is not set at all in the manipulation currently, use the existing value from the database
-                    if (!array_key_exists($k, $newManipulation['fields'] ?? [])) {
+                    // Do not include generated columns, cause we can't set values for those
+                    if (!array_key_exists($k, $newManipulation['fields'] ?? []) && !array_key_exists($k, $generatedColumns)) {
                         $newManipulation['fields'][$k] = $v;
                     }
                 }

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -8,6 +8,7 @@ use ReflectionMethod;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
@@ -26,6 +27,8 @@ use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\IdentityStore;
 use SilverStripe\Versioned\ChangeSet;
+use SilverStripe\Versioned\RestoreAction;
+use SilverStripe\Versioned\Tests\VersionedTest\TestGeneratedColumns;
 use SilverStripe\Versioned\Versioned;
 
 class VersionedTest extends SapphireTest
@@ -45,6 +48,8 @@ class VersionedTest extends SapphireTest
         VersionedTest\ChangeSetTestObject::class,
         VersionedTest\NoFixtureModel::class,
         VersionedTest\UnversionedWithField::class,
+        VersionedTest\UnversionedWithField::class,
+        VersionedTest\TestGeneratedColumns::class,
     ];
 
     public function testUniqueIndexes()
@@ -2161,5 +2166,27 @@ class VersionedTest extends SapphireTest
         $noDraftRecord2->write();
         $noDraftRecord2->publishSingle();
         $noDraftRecord2->deleteFromStage(Versioned::DRAFT);
+    }
+
+    /**
+     * Test there are no exceptions with versioned actions on a model with a generated column
+     */
+    #[DoesNotPerformAssertions]
+    public function testVersionWorksWithGeneratedColumns(): void
+    {
+        // Create new record
+        $record = new TestGeneratedColumns(['BaseField' => 'a value']);
+        $record->write();
+        // Publish
+        $record->publishSingle();
+        // Update draft
+        $record->BaseField = 'Second Value';
+        $record->write();
+        // Unpublish
+        $record->doUnpublish();
+        // Archive
+        $record->doArchive();
+        // Restore
+        RestoreAction::restore($record);
     }
 }

--- a/tests/php/VersionedTest/TestGeneratedColumns.php
+++ b/tests/php/VersionedTest/TestGeneratedColumns.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\VersionedTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * @mixin Versioned
+ */
+class TestGeneratedColumns extends DataObject implements TestOnly
+{
+    private static string $table_name = 'VersionedTest_TestGeneratedColumns';
+
+    private static array $db = [
+        'BaseField' => 'Varchar(255)',
+        'GeneratedField1' => 'Generated("Varchar(255)", "CONCAT(\\"BaseField\\", \'_etc\')", "VIRTUAL")',
+        'GeneratedField2' => 'Generated("Varchar(255)", "CONCAT(\\"BaseField\\", \'_etc\')", "STORED")',
+    ];
+
+    private static array $extensions = [
+        Versioned::class,
+    ];
+}


### PR DESCRIPTION
`Versioned` updates the db manipulation array directly instead of using `DBField::writeToManipulation()`, so we have to explicitly skip generated columns.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11774 for CI to go green


## Issue

- https://github.com/silverstripe/silverstripe-assets/issues/693