### PR TITLE
ENH Disable sorting on queries where sort order doesn't matter

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2499,7 +2499,7 @@ SQL
     protected function onPrepopulateTreeDataCache($recordList = null, array $options = [])
     {
         $idList = is_array($recordList) ? $recordList :
-            ($recordList instanceof DataList ? $recordList->column('ID') : null);
+            ($recordList instanceof DataList ? $recordList->sort(null)->column('ID') : null);
         Versioned::prepopulate_versionnumber_cache($this->owner->baseClass(), Versioned::DRAFT, $idList);
         Versioned::prepopulate_versionnumber_cache($this->owner->baseClass(), Versioned::LIVE, $idList);
     }


### PR DESCRIPTION
Sorting queries can be slow, especially on large datasets and especially if indexes aren't optimised. We should avoid sorting when the sort order doesn't matter.


## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11833