### PR TITLE
FIX Allow for null values returned from get_latest_version

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -2663,7 +2663,7 @@ SQL
      * @template T of DataObject
      * @param class-string<T> $class
      * @param int $id
-     * @return T&static
+     * @return null|T&static
      */
     public static function get_latest_version($class, $id)
     {
@@ -2692,7 +2692,7 @@ SQL
         }
 
         $version = static::get_latest_version($this->owner->baseClass(), $owner->ID);
-        return ($version->Version == $owner->Version);
+        return ($version?->Version == $owner->Version);
     }
 
     /**


### PR DESCRIPTION
While rare, it is possible for get_latest_version to return null, since it returns the value from `DataList::first()` which can return null if there's no record to return.

> [!IMPORTANT]
> This is required for https://github.com/tractorcow-farm/silverstripe-fluent/pull/1007

## Issue

- https://github.com/silverstripe/silverstripe-versioned/issues/525