### PR TITLE
ENH Exclude versioned GridField components when not needed

### DIFF
--- a/_config/versionedgridfield.yml
+++ b/_config/versionedgridfield.yml
@@ -11,6 +11,10 @@ SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor:
 SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor:
   extensions:
     - SilverStripe\Versioned\VersionedGridFieldArchiveExtension
+# Remove versioned components from non-versioned gridfields
+SilverStripe\Forms\GridField\GridField:
+  extensions:
+    - 'SilverStripe\Versioned\VersionedGridFieldRemoveComponentsExtension'
 # Enable gridfield extensions for dataobjects by default
 SilverStripe\ORM\DataObject:
   versioned_gridfield_extensions: true

--- a/src/VersionedGridFieldRemoveComponentsExtension.php
+++ b/src/VersionedGridFieldRemoveComponentsExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\Versioned;
+
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\GridField\GridField;
+
+/**
+ * Remove versioned components from a non-versioned gridfield
+ *
+ * @extends Extension<GridField>
+ */
+class VersionedGridFieldRemoveComponentsExtension extends Extension
+{
+    protected function onBeforeRenderHolder()
+    {
+        $owner = $this->getOwner();
+        $modelClass = $owner->getModelClass();
+        if (!method_exists($modelClass, 'has_extension') || !$modelClass::has_extension(Versioned::class)) {
+            $owner->getConfig()->removeComponentsByType([GridFieldArchiveAction::class, GridFieldRestoreAction::class]);
+        }
+    }
+}

--- a/tests/php/VersionedGridFieldTest.php
+++ b/tests/php/VersionedGridFieldTest.php
@@ -2,8 +2,15 @@
 
 namespace SilverStripe\Versioned\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
+use SilverStripe\Versioned\GridFieldArchiveAction;
+use SilverStripe\Versioned\GridFieldRestoreAction;
 use SilverStripe\Versioned\Versioned;
 
 class VersionedGridFieldTest extends FunctionalTest
@@ -55,5 +62,43 @@ class VersionedGridFieldTest extends FunctionalTest
         $this->assertNotNull($livePage);
         $this->assertEquals('Page 1 renamed', $draftPage->Title);
         $this->assertEquals('Page 1 renamed', $livePage->Title);
+    }
+
+    public static function provideOnBeforeRenderHolder(): array
+    {
+        return [
+            'versioned' => [
+                'modelClass' => VersionedTest\TestObject::class,
+                'hasComponents' => true,
+            ],
+            'not-versioned' => [
+                'modelClass' => VersionedTest\RelatedWithoutversion::class,
+                'hasComponents' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideOnBeforeRenderHolder')]
+    public function testOnBeforeRenderHolder(string $modelClass, bool $hasComponents): void
+    {
+        $config = new GridFieldConfig_RecordEditor();
+        $archiveComponent = $config->getComponentsByType(GridFieldArchiveAction::class);
+        $restoreComponent = $config->getComponentsByType(GridFieldRestoreAction::class);
+        $this->assertCount(1, $archiveComponent);
+        $this->assertCount(0, $restoreComponent);
+        $config->addComponent(new GridFieldRestoreAction());
+
+        $gridField = new GridField('test', 'test', $modelClass::get(), $config);
+        $form = new Form(new VersionedGridFieldTest\TestController(), fields: new FieldList($gridField));
+        $gridField->FieldHolder();
+        $archiveComponent = $config->getComponentsByType(GridFieldArchiveAction::class);
+        $restoreComponent = $config->getComponentsByType(GridFieldRestoreAction::class);
+        if ($hasComponents) {
+            $this->assertCount(1, $archiveComponent);
+            $this->assertCount(1, $restoreComponent);
+        } else {
+            $this->assertCount(0, $archiveComponent);
+            $this->assertCount(0, $restoreComponent);
+        }
     }
 }


### PR DESCRIPTION
If the model class isn't versioned, those components shouldn't factor into the rendering logic, which affects whether there's an actions column or not if no other actions are present.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11817