### PR TITLE
FIX Don't crash if there's no model class in gridfield

### DIFF
--- a/src/VersionedGridFieldRemoveComponentsExtension.php
+++ b/src/VersionedGridFieldRemoveComponentsExtension.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\Versioned;
 
-use SilverStripe\Core\ClassInfo;
+use LogicException;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\GridField\GridField;
 
@@ -16,7 +16,15 @@ class VersionedGridFieldRemoveComponentsExtension extends Extension
     protected function onBeforeRenderHolder()
     {
         $owner = $this->getOwner();
-        $modelClass = $owner->getModelClass();
+        try {
+            $modelClass = $owner->getModelClass();
+        } catch (LogicException) {
+            // noop - it's possible to have a gridfield with custom components that don't rely on columns
+            // from the records in the list.
+            // Or more likely - an empty gridfield.
+            return;
+        }
+
         if (!method_exists($modelClass, 'has_extension') || !$modelClass::has_extension(Versioned::class)) {
             $owner->getConfig()->removeComponentsByType([GridFieldArchiveAction::class, GridFieldRestoreAction::class]);
         }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-reports/actions/runs/18870669305/job/53848059007 and https://github.com/silverstripe/silverstripe-framework/actions/runs/18835051455/job/53734250875

The error when going to the external link report locally is:

```text
[Emergency] Uncaught LogicException: GridField doesn't have a modelClassName, so it doesn't know the columns of this grid.
Line 241 in /var/www/html/vendor/silverstripe/framework/src/Forms/GridField/GridField.php
Trace
    SilverStripe\Forms\GridField\GridField->getModelClass()
    VersionedGridFieldRemoveComponentsExtension.php:19
```

## Issue

- https://github.com/silverstripe/.github/issues/460