### PR TITLE
FIX: Do not show More Options when no actions

### DIFF
--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -403,9 +403,16 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
 
             if ($actionMenusMoreOptions) {
                 // Check if there are any FormAction fields (recursively through nested tabs)
-                if (!$actionMenusMoreOptions->Fields()->flattenFields()->filterByCallback(function ($field) {
-                    return $field instanceof FormAction;
-                })->first()) {
+                $hasFormAction = false;
+                $actionMenusMoreOptions->Fields()->recursiveWalk(function ($field) use (&$hasFormAction) {
+                    if ($field instanceof FormAction) {
+                        $hasFormAction = true;
+                        return false; // Stop walking
+                    }
+                    return true; // Continue walking
+                });
+
+                if (!$hasFormAction) {
                     $form->Actions()->removeByName('ActionMenus');
                 }
             }

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -395,7 +395,10 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             $moreOptions->push($actionArchive);
         }
 
-        $actions->insertAfter('MajorActions', $rootTabSet);
+        // Only add $moreOptions menu if it contains action buttons
+        if ($moreOptions->Fields()->count() > 1) {
+            $actions->insertAfter('MajorActions', $rootTabSet);
+        }
     }
 
     /**

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -395,10 +395,21 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
             $moreOptions->push($actionArchive);
         }
 
-        // Only add $moreOptions menu if it contains action buttons
-        if ($moreOptions->Fields()->count() > 1) {
-            $actions->insertAfter('MajorActions', $rootTabSet);
-        }
+        $actions->insertAfter('MajorActions', $rootTabSet);
+
+        // Remove ActionMenus when ActionMenus.MoreOptions has no actions
+        $this->afterExtending('updateItemEditForm', function (Form $form) {
+            $actionMenusMoreOptions = $form->Actions()->findTab('ActionMenus.MoreOptions');
+
+            if ($actionMenusMoreOptions) {
+                // Check if there are any FormAction fields (recursively through nested tabs)
+                if (!$actionMenusMoreOptions->Fields()->flattenFields()->filterByCallback(function ($field) {
+                    return $field instanceof FormAction;
+                })->first()) {
+                    $form->Actions()->removeByName('ActionMenus');
+                }
+            }
+        });
     }
 
     /**

--- a/src/VersionedGridFieldItemRequest.php
+++ b/src/VersionedGridFieldItemRequest.php
@@ -397,22 +397,20 @@ class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest
 
         $actions->insertAfter('MajorActions', $rootTabSet);
 
-        // Remove ActionMenus when ActionMenus.MoreOptions has no actions
+        // Remove ActionMenus when ActionMenus.MoreOptions has no content
         $this->afterExtending('updateItemEditForm', function (Form $form) {
             $actionMenusMoreOptions = $form->Actions()->findTab('ActionMenus.MoreOptions');
 
             if ($actionMenusMoreOptions) {
-                // Check if there are any FormAction fields (recursively through nested tabs)
-                $hasFormAction = false;
-                $actionMenusMoreOptions->Fields()->recursiveWalk(function ($field) use (&$hasFormAction) {
-                    if ($field instanceof FormAction) {
-                        $hasFormAction = true;
-                        return false; // Stop walking
+                // Check if there are any fields other than structural Tab/TabSet fields
+                $hasContent = false;
+                $actionMenusMoreOptions->Fields()->recursiveWalk(function ($field) use (&$hasContent) {
+                    if (!$field instanceof Tab && !$field instanceof TabSet) {
+                        $hasContent = true;
                     }
-                    return true; // Continue walking
                 });
 
-                if (!$hasFormAction) {
+                if (!$hasContent) {
                     $form->Actions()->removeByName('ActionMenus');
                 }
             }

--- a/tests/php/VersionedGridFieldItemRequestTest.php
+++ b/tests/php/VersionedGridFieldItemRequestTest.php
@@ -207,7 +207,7 @@ class VersionedGridFieldItemRequestTest extends SapphireTest
         $actionMenus = $actions->fieldByName('ActionMenus');
         $this->assertNull(
             $actionMenus,
-            'ActionMenus should be removed when MoreOptions has no FormAction fields'
+            'ActionMenus should be removed when MoreOptions has no content other than structural Tab/TabSet fields'
         );
     }
 

--- a/tests/php/VersionedGridFieldItemRequestTest.php
+++ b/tests/php/VersionedGridFieldItemRequestTest.php
@@ -11,6 +11,7 @@ use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Tests\VersionedGridFieldItemRequestTest\TestExtension;
 use SilverStripe\Versioned\Tests\VersionedGridFieldItemRequestTest\UnversionedObject;
 use SilverStripe\Versioned\Tests\VersionedGridFieldItemRequestTest\UnversionedOwner;
 use SilverStripe\Versioned\Tests\VersionedGridFieldItemRequestTest\VersionedObject;
@@ -149,6 +150,65 @@ class VersionedGridFieldItemRequestTest extends SapphireTest
 
         // Warning was removed as part of #154 ... it may be brough back later
         $this->assertNull($warningField);
+    }
+
+    /**
+     * Test that ActionMenus is added when an extension adds actions via updateFormActions
+     */
+    public function testActionMenusAddedWhenExtensionAddsActions()
+    {
+        // Enable the test extension to add an action
+        TestExtension::$add_test_action = true;
+        VersionedGridFieldItemRequest::add_extension(TestExtension::class);
+
+        try {
+            $testObject = $this->objFromFixture(VersionedObject::class, 'object-1');
+            $itemRequest = $this->createItemRequestForObject($testObject);
+            $this->logInWithPermission('ADMIN');
+            $form = $itemRequest->ItemEditForm();
+            $actions = $form->Actions();
+
+            // ActionMenus should be present
+            $actionMenus = $actions->fieldByName('ActionMenus');
+            $this->assertNotNull($actionMenus, 'ActionMenus should be present when extension adds actions');
+
+            // MoreOptions should contain the test action
+            $moreOptions = $actionMenus->fieldByName('MoreOptions');
+            $this->assertNotNull($moreOptions, 'MoreOptions should be present');
+
+            $testAction = $moreOptions->fieldByName('action_doTestAction');
+            $this->assertInstanceOf(
+                FormAction::class,
+                $testAction,
+                'Test action added by extension should be present'
+            );
+        } finally {
+            // Clean up
+            TestExtension::$add_test_action = false;
+            VersionedGridFieldItemRequest::remove_extension(TestExtension::class);
+        }
+    }
+
+    /**
+     * Test that ActionMenus is removed when there are no actions in MoreOptions
+     */
+    public function testActionMenusRemovedWhenNoActions()
+    {
+        // Create an unversioned owner which has no archive action
+        $testObject = UnversionedOwner::create();
+        $testObject->write();
+
+        $itemRequest = $this->createItemRequestForObject($testObject);
+        $this->logInWithPermission('ADMIN');
+        $form = $itemRequest->ItemEditForm();
+        $actions = $form->Actions();
+
+        // ActionMenus should not be present when there are no actions
+        $actionMenus = $actions->fieldByName('ActionMenus');
+        $this->assertNull(
+            $actionMenus,
+            'ActionMenus should be removed when MoreOptions has no FormAction fields'
+        );
     }
 
     protected function createItemRequestForObject(DataObject $obj)

--- a/tests/php/VersionedGridFieldItemRequestTest/TestExtension.php
+++ b/tests/php/VersionedGridFieldItemRequestTest/TestExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\Versioned\Tests\VersionedGridFieldItemRequestTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FormAction;
+
+/**
+ * Test extension that adds actions via updateFormActions
+ */
+class TestExtension extends Extension implements TestOnly
+{
+    /**
+     * @var bool Flag to control whether to add actions
+     */
+    public static $add_test_action = false;
+
+    public function updateFormActions(FieldList $actions)
+    {
+        if (self::$add_test_action) {
+            $moreOptions = $actions->findOrMakeTab('ActionMenus.MoreOptions');
+            $moreOptions->push(FormAction::create('doTestAction', 'Test Action'));
+        }
+    }
+}

--- a/tests/php/VersionedGridFieldItemRequestTest/TestExtension.php
+++ b/tests/php/VersionedGridFieldItemRequestTest/TestExtension.php
@@ -13,13 +13,13 @@ use SilverStripe\Forms\FormAction;
 class TestExtension extends Extension implements TestOnly
 {
     /**
-     * @var bool Flag to control whether to add actions
+     * Flag to control whether to add actions
      */
-    public static $add_test_action = false;
+    public static bool $add_test_action = false;
 
     public function updateFormActions(FieldList $actions)
     {
-        if (self::$add_test_action) {
+        if (static::$add_test_action) {
             $moreOptions = $actions->findOrMakeTab('ActionMenus.MoreOptions');
             $moreOptions->push(FormAction::create('doTestAction', 'Test Action'));
         }


### PR DESCRIPTION
## Description
In a versioned DataObject, if we restrict users from unpublishing and archiving the object, the more options menu still shows. Fixed with simply checking if optionsMenu contains actions.

## Manual testing steps
Create a Dataobject which has canPublish and canArchive set to false and optionsMenu will be gone.

## Issues
#298 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
