### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/PublishRecursive/SlowDummyObject.php
+++ b/tests/php/PublishRecursive/SlowDummyObject.php
@@ -78,8 +78,6 @@ class SlowDummyObject extends DataObject implements TestOnly
     private function getMockNow()
     {
         $propertyMockNow = new ReflectionProperty(DBDatetime::class, 'mock_now');
-        $propertyMockNow->setAccessible(true);
-
         return $propertyMockNow->getValue();
     }
 }

--- a/tests/php/PublishRecursive/SlowDummyParent.php
+++ b/tests/php/PublishRecursive/SlowDummyParent.php
@@ -94,8 +94,6 @@ class SlowDummyParent extends DataObject implements TestOnly
     private function getMockNow()
     {
         $propertyMockNow = new ReflectionProperty(DBDatetime::class, 'mock_now');
-        $propertyMockNow->setAccessible(true);
-
         return $propertyMockNow->getValue();
     }
 }

--- a/tests/php/Traits/VersionNumberCacheTraitTest.php
+++ b/tests/php/Traits/VersionNumberCacheTraitTest.php
@@ -151,14 +151,12 @@ class VersionNumberCacheTraitTest extends SapphireTest
     private function getCache(): ?array
     {
         $refl = new ReflectionProperty(TestTraitHolder::class, 'cache_versionnumber');
-        $refl->setAccessible(true);
         return $refl->getValue();
     }
 
     private function resetCache(): ?array
     {
         $refl = new ReflectionProperty(TestTraitHolder::class, 'cache_versionnumber');
-        $refl->setAccessible(true);
         // The property unset by default, though getting its value will resolve to null
         // so this is good enough
         return $refl->setValue(null, null);

--- a/tests/php/VersionedNumberCacheTest.php
+++ b/tests/php/VersionedNumberCacheTest.php
@@ -102,7 +102,6 @@ class VersionedNumberCacheTest extends SapphireTest
         $ext = new Versioned();
         $ext->setOwner($owner);
         $method = new ReflectionMethod(Versioned::class, 'onPrepopulateTreeDataCache');
-        $method->setAccessible(true);
         $method->invoke($ext);
         $actual = Versioned::get_versionnumber_by_stage(TestObject::class, $stage, VersionedNumberCacheTest::${$ID}, $cache);
         $this->assertEquals(VersionedNumberCacheTest::$expectedVersions[$expected], $actual);

--- a/tests/php/VersionedTest.php
+++ b/tests/php/VersionedTest.php
@@ -116,7 +116,6 @@ class VersionedTest extends SapphireTest
         // Note: Pass in table names in incorrect case intentionally
         // to test that it internally corrects itself
         $method = new ReflectionMethod(Versioned::class, 'cleanupVersionedOrphans');
-        $method->setAccessible(true);
         $extension = $obj->getExtensionInstance(Versioned::class);
         $extension->setOwner($obj);
         try {


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.