### PR TITLE
FIX Allow a null object when getting changeset edit link

### DIFF
--- a/src/ChangeSetItem.php
+++ b/src/ChangeSetItem.php
@@ -170,7 +170,7 @@ class ChangeSetItem extends DataObject implements Thumbnail
      * If the object isn't versioned it will return the normal record.
      *
      * @param string $stage
-     * @return DataObject|Versioned|RecursivePublishable Object in this stage (may not be Versioned)
+     * @return DataObject|Versioned|RecursivePublishable|null Object in this stage (may not be Versioned)
      * @throws UnexpectedDataException
      */
     protected function getObjectInStage($stage)
@@ -534,7 +534,7 @@ class ChangeSetItem extends DataObject implements Thumbnail
     public function CMSEditLink(): ?string
     {
         $link = $this->getObjectInStage(Versioned::DRAFT);
-        return $link->CMSEditLink();
+        return $link?->CMSEditLink();
     }
 
     /**

--- a/tests/php/ChangeSetItemTest.php
+++ b/tests/php/ChangeSetItemTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Versioned\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Versioned\ChangeSetItem;
 use SilverStripe\Dev\SapphireTest;
 
@@ -122,5 +123,35 @@ class ChangeSetItemTest extends SapphireTest
 
         // Should not error
         $item->publish();
+    }
+
+    public static function provideCMSEditLink(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    #[DataProvider('provideCMSEditLink')]
+    public function testCMSEditLink(bool $objectExists): void
+    {
+        $object = new ChangeSetItemTest\UnstagedObject(['Bar' => 2]);
+        if ($objectExists) {
+            $object->write();
+        }
+        $item = new ChangeSetItem(
+            [
+                'ObjectID' => $object->ID,
+                'ObjectClass' => $object->baseClass(),
+            ]
+        );
+
+        $link = $item->CMSEditLink();
+        if ($objectExists) {
+            $this->assertSame('test-path', $link);
+        } else {
+            $this->assertNull($link);
+        }
     }
 }

--- a/tests/php/ChangeSetItemTest/UnstagedObject.php
+++ b/tests/php/ChangeSetItemTest/UnstagedObject.php
@@ -31,4 +31,9 @@ class UnstagedObject extends DataObject implements TestOnly
         // Should be ignored
         return false;
     }
+
+    public function getCMSEditLink(): ?string
+    {
+        return 'test-path';
+    }
 }


### PR DESCRIPTION
`ChangeSetItem::getObjectInStage()` returns the value of `DataList::byID()` which is explicitly nullable. It needs to handle null values.

Otherwise we get this error after https://github.com/silverstripe/silverstripe-assets/pull/707 gets merged:

> ERROR [Emergency]: Uncaught Error: Call to a member function CMSEditLink() on null
> IN GET /admin/campaigns/sets
> Line 537 in /var/www/html/vendor/silverstripe/versioned/src/ChangeSetItem.php

## Issue

- https://github.com/silverstripe/silverstripe-campaign-admin/issues/393