### PR TITLE
API Keys should be of type ForeignKey instead of hardcoded to Int

### DIFF
--- a/src/Versioned.php
+++ b/src/Versioned.php
@@ -155,13 +155,13 @@ class Versioned extends Extension implements TemplateGlobalProvider, Resettable
      * @var array $db_for_versions_table
      */
     private static $db_for_versions_table = [
-        "RecordID" => "Int",
+        "RecordID" => "ForeignKey",
         "Version" => "Int",
         "WasPublished" => "Boolean",
         "WasDeleted" => "Boolean",
         "WasDraft" => "Boolean(1)",
-        "AuthorID" => "Int",
-        "PublisherID" => "Int"
+        "AuthorID" => "ForeignKey",
+        "PublisherID" => "ForeignKey"
     ];
 
     /**
@@ -171,12 +171,12 @@ class Versioned extends Extension implements TemplateGlobalProvider, Resettable
      * @var array
      */
     private static $casting = [
-        "RecordID" => "Int",
+        "RecordID" => "ForeignKey",
         "WasPublished" => "Boolean",
         "WasDeleted" => "Boolean",
         "WasDraft" => "Boolean",
-        "AuthorID" => "Int",
-        "PublisherID" => "Int"
+        "AuthorID" => "ForeignKey",
+        "PublisherID" => "ForeignKey"
     ];
 
     /**
@@ -1045,7 +1045,7 @@ SQL
                     // Create fields for any tables of subclasses
                     $versionFields = array_merge(
                         [
-                            "RecordID" => "Int",
+                            "RecordID" => "ForeignKey",
                             "Version" => "Int",
                         ],
                         (array)$fields


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
The RecordID, AuthorID and PublisherID are currently hardcoded to Int. I think that should be changed to the distinct ForeignKey type. So it can be overwritten when needed.

For example the postgres module uses bigint for the primary key, so the RecordID should have the same type.

## Issues
- #543

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
